### PR TITLE
1. GroupBy Alias Support in RelToSqlConverter.

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
@@ -254,11 +254,12 @@ public class RelToSqlConverter extends SqlImplementor
 
     final List<SqlNode> groupKeys = new ArrayList<>();
     for (int key : groupList) {
-      final SqlNode field = builder.context.field(key);
+      boolean isGroupByAlias = dialect.getSqlConformance().isGroupByAlias();
+      final SqlNode field = builder.context.field(key, isGroupByAlias);
       groupKeys.add(field);
     }
     for (int key : sortedGroupList) {
-      final SqlNode field = builder.context.field(key);
+      final SqlNode field = builder.context.field(key, false);
       addSelect(selectList, field, aggregate.getRowType());
     }
     switch (aggregate.getGroupType()) {

--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
@@ -433,6 +433,8 @@ public abstract class SqlImplementor {
 
     public abstract SqlNode field(int ordinal);
 
+    public abstract SqlNode field(int ordinal, boolean useAlias);
+
     /** Converts an expression from {@link RexNode} to {@link SqlNode}
      * format.
      *
@@ -866,6 +868,10 @@ public abstract class SqlImplementor {
       this.field = field;
     }
 
+    public SqlNode field(int ordinal, boolean useAlias) {
+      throw new IllegalStateException("SHouldn't be here");
+    }
+
     public SqlNode field(int ordinal) {
       return field.apply(ordinal);
     }
@@ -943,6 +949,12 @@ public abstract class SqlImplementor {
       this.qualified = qualified;
     }
 
+    public SqlNode field(int ordinal, boolean useAlias) {
+      //Falling back to default behaviour & ignoring useAlias.
+      // We can handle this as & when use cases arise.
+      return field(ordinal);
+    }
+
     public SqlNode field(int ordinal) {
       for (Map.Entry<String, RelDataType> alias : aliases.entrySet()) {
         final List<RelDataTypeField> fields = alias.getValue().getFieldList();
@@ -977,6 +989,10 @@ public abstract class SqlImplementor {
       super(dialect, leftContext.fieldCount + rightContext.fieldCount);
       this.leftContext = leftContext;
       this.rightContext = rightContext;
+    }
+
+    public SqlNode field(int ordinal, boolean useAlias) {
+      throw new IllegalStateException("SHouldn't be here");
     }
 
     public SqlNode field(int ordinal) {
@@ -1070,6 +1086,17 @@ public abstract class SqlImplementor {
                 return ((SqlCall) selectItem).operand(1);
               }
                 return ((SqlCall) selectItem).operand(0);
+            }
+            return selectItem;
+          }
+          public SqlNode field(int ordinal, boolean useAlias) {
+            final SqlNode selectItem = selectList.get(ordinal);
+            switch (selectItem.getKind()) {
+            case AS:
+              if (useAlias) {
+                return ((SqlCall) selectItem).operand(1);
+              }
+              return ((SqlCall) selectItem).operand(0);
             }
             return selectItem;
           }

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlConformanceEnum.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlConformanceEnum.java
@@ -93,6 +93,7 @@ public enum SqlConformanceEnum implements SqlConformance {
     case BABEL:
     case LENIENT:
     case MYSQL_5:
+    case BIG_QUERY:
       return true;
     default:
       return false;

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -300,6 +300,28 @@ public class RelToSqlConverterTest {
         .ok(expectedHive);
   }
 
+  @Test public void testSimpleSelectWithGroupByAlias() {
+    final String query = "select 'literal' as \"a\", sku + 1 as b from"
+        + " \"product\" group by 'literal', sku + 1";
+    final String bigQueryExpected = "SELECT 'literal' AS a, SKU + 1 AS B\n"
+        + "FROM foodmart.product\n"
+        + "GROUP BY a, B";
+    sql(query)
+        .withBigquery()
+        .ok(bigQueryExpected);
+  }
+
+  @Test public void testSimpleSelectWithGroupByAliasAndAggregate() {
+    final String query = "select 'literal' as \"a\", sku + 1 as b, sum(\"product_id\") from"
+        + " \"product\" group by 'literal', sku + 1";
+    final String bigQueryExpected = "SELECT 'literal' AS a, SKU + 1 AS B, SUM(product_id)\n"
+        + "FROM foodmart.product\n"
+        + "GROUP BY a, B";
+    sql(query)
+        .withBigquery()
+        .ok(bigQueryExpected);
+  }
+
   /** CUBE of one column is equivalent to ROLLUP, and Calcite recognizes
    * this. */
   @Test public void testSelectQueryWithSingletonCube() {


### PR DESCRIPTION
2. Changed SqlConformance.allowsGroupByAlias() to include BigQuery.