### PR TITLE
"Cast null as null" fix

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
@@ -72,6 +72,7 @@ import org.apache.calcite.sql.fun.SqlRowOperator;
 import org.apache.calcite.sql.fun.SqlSingleValueAggFunction;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.validate.SqlValidatorUtil;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.Pair;
@@ -228,7 +229,9 @@ public class RelToSqlConverter extends SqlImplementor
     final List<SqlNode> selectList = new ArrayList<>();
     for (RexNode ref : e.getChildExps()) {
       SqlNode sqlExpr = builder.context.toSql(null, ref);
-      if (SqlUtil.isNullLiteral(sqlExpr, false)) {
+      if (SqlUtil.isNullLiteral(sqlExpr, false)
+          && e.getRowType().getFieldList().get(selectList.size()).getType()
+          .getSqlTypeName() != SqlTypeName.NULL) {
         sqlExpr = castNullType(sqlExpr, e.getRowType().getFieldList().get(selectList.size()));
       }
       addSelect(selectList, sqlExpr, e.getRowType());

--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
@@ -229,10 +229,10 @@ public class RelToSqlConverter extends SqlImplementor
     final List<SqlNode> selectList = new ArrayList<>();
     for (RexNode ref : e.getChildExps()) {
       SqlNode sqlExpr = builder.context.toSql(null, ref);
+      RelDataTypeField targetField = e.getRowType().getFieldList().get(selectList.size());
       if (SqlUtil.isNullLiteral(sqlExpr, false)
-          && e.getRowType().getFieldList().get(selectList.size()).getType()
-          .getSqlTypeName() != SqlTypeName.NULL) {
-        sqlExpr = castNullType(sqlExpr, e.getRowType().getFieldList().get(selectList.size()));
+          && targetField.getType().getSqlTypeName() != SqlTypeName.NULL) {
+        sqlExpr = castNullType(sqlExpr, targetField);
       }
       addSelect(selectList, sqlExpr, e.getRowType());
     }


### PR DESCRIPTION
**Problem:**
Right now if we simply say 
`select null from employee`
then calcite prints
`select cast(null as null) from employee`
in the above case we need not cast `NULL`. 

**Fix:**
If the target type is non null then only we'll cast `NULL` to target else don't.