### PR TITLE
allowing serialization for SqlIntervalQualifier class

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlIntervalQualifier.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlIntervalQualifier.java
@@ -29,6 +29,7 @@ import org.apache.calcite.sql.validate.SqlValidatorScope;
 import org.apache.calcite.util.Litmus;
 import org.apache.calcite.util.Util;
 
+import java.io.Serializable;
 import java.math.BigDecimal;
 import java.util.Objects;
 import java.util.regex.Matcher;
@@ -81,7 +82,7 @@ import static org.apache.calcite.util.Static.RESOURCE;
  *
  * <p>An instance of this class is immutable.
  */
-public class SqlIntervalQualifier extends SqlNode {
+public class SqlIntervalQualifier extends SqlNode implements Serializable {
   //~ Static fields/initializers ---------------------------------------------
 
   private static final BigDecimal ZERO = BigDecimal.ZERO;


### PR DESCRIPTION
**Details:**
In a scenario where we serialize the database schema information, we serialize calcite data types / sql node and use it later in subsequent steps. In order to achieve the serialization we need `SqlIntervalQualifier` to be serialized.

**Implementation Details:**
`SqlIntervalQualifier` is now implementing the `Serializable` interface.

**Jira:**
https://datametica.atlassian.net/browse/EEF-2972