### PR TITLE
allowing serialization for SqlNode class

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlIntervalQualifier.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlIntervalQualifier.java
@@ -29,7 +29,6 @@ import org.apache.calcite.sql.validate.SqlValidatorScope;
 import org.apache.calcite.util.Litmus;
 import org.apache.calcite.util.Util;
 
-import java.io.Serializable;
 import java.math.BigDecimal;
 import java.util.Objects;
 import java.util.regex.Matcher;
@@ -82,7 +81,7 @@ import static org.apache.calcite.util.Static.RESOURCE;
  *
  * <p>An instance of this class is immutable.
  */
-public class SqlIntervalQualifier extends SqlNode implements Serializable {
+public class SqlIntervalQualifier extends SqlNode {
   //~ Static fields/initializers ---------------------------------------------
 
   private static final BigDecimal ZERO = BigDecimal.ZERO;

--- a/core/src/main/java/org/apache/calcite/sql/SqlNode.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlNode.java
@@ -28,6 +28,7 @@ import org.apache.calcite.sql.validate.SqlValidatorScope;
 import org.apache.calcite.util.Litmus;
 import org.apache.calcite.util.Util;
 
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
@@ -41,7 +42,7 @@ import javax.annotation.Nonnull;
  * {@link SqlOperator operator}, {@link SqlLiteral literal},
  * {@link SqlIdentifier identifier}, and so forth.
  */
-public abstract class SqlNode implements Cloneable {
+public abstract class SqlNode implements Cloneable, Serializable {
   //~ Static fields/initializers ---------------------------------------------
 
   public static final SqlNode[] EMPTY_ARRAY = new SqlNode[0];


### PR DESCRIPTION
Details:
In a scenario where we serialize the database schema information, we serialize calcite data types / sql node and use it later in subsequent steps. In order to achieve the serialization we need `SqlNode` to be serialized.

Implementation Details:
`SqlNode` is now implementing the Serializable interface.

Jira:
https://datametica.atlassian.net/browse/EEF-2972