### PR TITLE
CHARACTER_LENGTH() printed as LENGTH() in BQ

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
@@ -300,6 +300,7 @@ public class BigQuerySqlDialect extends SqlDialect {
         super.unparseCall(writer, call, leftPrec, rightPrec);
       }
       break;
+    case CHARACTER_LENGTH:
     case CHAR_LENGTH:
       final SqlWriter.Frame lengthFrame = writer.startFunCall("LENGTH");
       call.operand(0).unparse(writer, leftPrec, rightPrec);


### PR DESCRIPTION
Added a switch case for character_length function so that it is printed as LENGTH in BQ