### PR TITLE
Flag to check if Insert clause in Merge queries require columns

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
@@ -1191,6 +1191,13 @@ public class SqlDialect {
     return false;
   }
 
+  /**
+   * Return whether this dialect requires Column names in the INSERT clause of MERGE statements.
+   */
+  public boolean requiresColumnsInMergeInsertClause() {
+    return false;
+  }
+
   /** Returns how NULL values are sorted if an ORDER BY item does not contain
    * NULLS ASCENDING or NULLS DESCENDING. */
   public NullCollation getNullCollation() {

--- a/core/src/main/java/org/apache/calcite/sql/dialect/AccessSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/AccessSqlDialect.java
@@ -36,4 +36,8 @@ public class AccessSqlDialect extends SqlDialect {
   @Override public boolean supportsWindowFunctions() {
     return false;
   }
+
+  @Override public boolean requiresColumnsInMergeInsertClause() {
+    throw new UnsupportedOperationException();
+  }
 }

--- a/core/src/main/java/org/apache/calcite/sql/dialect/AnsiSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/AnsiSqlDialect.java
@@ -38,4 +38,8 @@ public class AnsiSqlDialect extends SqlDialect {
   public AnsiSqlDialect(Context context) {
     super(context);
   }
+
+  @Override public boolean requiresColumnsInMergeInsertClause() {
+    throw new UnsupportedOperationException();
+  }
 }

--- a/core/src/main/java/org/apache/calcite/sql/dialect/CalciteSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/CalciteSqlDialect.java
@@ -39,4 +39,8 @@ public class CalciteSqlDialect extends SqlDialect {
   public CalciteSqlDialect(Context context) {
     super(context);
   }
+
+  @Override public boolean requiresColumnsInMergeInsertClause() {
+    throw new UnsupportedOperationException();
+  }
 }

--- a/core/src/main/java/org/apache/calcite/sql/dialect/ClickHouseSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/ClickHouseSqlDialect.java
@@ -68,6 +68,10 @@ public class ClickHouseSqlDialect extends SqlDialect {
     return false;
   }
 
+  @Override public boolean requiresColumnsInMergeInsertClause() {
+    throw new UnsupportedOperationException();
+  }
+
   @Override public CalendarPolicy getCalendarPolicy() {
     return CalendarPolicy.SHIFT;
   }

--- a/core/src/main/java/org/apache/calcite/sql/dialect/Db2SqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/Db2SqlDialect.java
@@ -44,6 +44,10 @@ public class Db2SqlDialect extends SqlDialect {
     return false;
   }
 
+  @Override public boolean requiresColumnsInMergeInsertClause() {
+    throw new UnsupportedOperationException();
+  }
+
   @Override public void unparseSqlIntervalQualifier(SqlWriter writer,
       SqlIntervalQualifier qualifier, RelDataTypeSystem typeSystem) {
 

--- a/core/src/main/java/org/apache/calcite/sql/dialect/DerbySqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/DerbySqlDialect.java
@@ -31,4 +31,8 @@ public class DerbySqlDialect extends SqlDialect {
   public DerbySqlDialect(Context context) {
     super(context);
   }
+
+  @Override public boolean requiresColumnsInMergeInsertClause() {
+    throw new UnsupportedOperationException();
+  }
 }

--- a/core/src/main/java/org/apache/calcite/sql/dialect/FirebirdSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/FirebirdSqlDialect.java
@@ -31,4 +31,8 @@ public class FirebirdSqlDialect extends SqlDialect {
   public FirebirdSqlDialect(Context context) {
     super(context);
   }
+
+  @Override public boolean requiresColumnsInMergeInsertClause() {
+    throw new UnsupportedOperationException();
+  }
 }

--- a/core/src/main/java/org/apache/calcite/sql/dialect/H2SqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/H2SqlDialect.java
@@ -40,4 +40,8 @@ public class H2SqlDialect extends SqlDialect {
   @Override public boolean supportsWindowFunctions() {
     return false;
   }
+
+  @Override public boolean requiresColumnsInMergeInsertClause() {
+    throw new UnsupportedOperationException();
+  }
 }

--- a/core/src/main/java/org/apache/calcite/sql/dialect/HsqldbSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/HsqldbSqlDialect.java
@@ -57,6 +57,10 @@ public class HsqldbSqlDialect extends SqlDialect {
     return false;
   }
 
+  @Override public boolean requiresColumnsInMergeInsertClause() {
+    throw new UnsupportedOperationException();
+  }
+
   @Override public void unparseCall(SqlWriter writer, SqlCall call,
       int leftPrec, int rightPrec) {
     switch (call.getKind()) {

--- a/core/src/main/java/org/apache/calcite/sql/dialect/InfobrightSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/InfobrightSqlDialect.java
@@ -37,4 +37,8 @@ public class InfobrightSqlDialect extends SqlDialect {
     return false;
   }
 
+  @Override public boolean requiresColumnsInMergeInsertClause() {
+    throw new UnsupportedOperationException();
+  }
+
 }

--- a/core/src/main/java/org/apache/calcite/sql/dialect/InformixSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/InformixSqlDialect.java
@@ -31,4 +31,8 @@ public class InformixSqlDialect extends SqlDialect {
   public InformixSqlDialect(Context context) {
     super(context);
   }
+
+  @Override public boolean requiresColumnsInMergeInsertClause() {
+    throw new UnsupportedOperationException();
+  }
 }

--- a/core/src/main/java/org/apache/calcite/sql/dialect/IngresSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/IngresSqlDialect.java
@@ -31,4 +31,8 @@ public class IngresSqlDialect extends SqlDialect {
   public IngresSqlDialect(Context context) {
     super(context);
   }
+
+  @Override public boolean requiresColumnsInMergeInsertClause() {
+    throw new UnsupportedOperationException();
+  }
 }

--- a/core/src/main/java/org/apache/calcite/sql/dialect/InterbaseSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/InterbaseSqlDialect.java
@@ -31,4 +31,8 @@ public class InterbaseSqlDialect extends SqlDialect {
   public InterbaseSqlDialect(Context context) {
     super(context);
   }
+
+  @Override public boolean requiresColumnsInMergeInsertClause() {
+    throw new UnsupportedOperationException();
+  }
 }

--- a/core/src/main/java/org/apache/calcite/sql/dialect/LucidDbSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/LucidDbSqlDialect.java
@@ -32,4 +32,8 @@ public class LucidDbSqlDialect extends SqlDialect {
   public LucidDbSqlDialect(Context context) {
     super(context);
   }
+
+  @Override public boolean requiresColumnsInMergeInsertClause() {
+    throw new UnsupportedOperationException();
+  }
 }

--- a/core/src/main/java/org/apache/calcite/sql/dialect/MssqlSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/MssqlSqlDialect.java
@@ -91,6 +91,10 @@ public class MssqlSqlDialect extends SqlDialect {
     top = context.databaseMajorVersion() < 11;
   }
 
+  @Override public boolean requiresColumnsInMergeInsertClause() {
+    throw new UnsupportedOperationException();
+  }
+
   /** {@inheritDoc}
    *
    * <p>MSSQL does not support NULLS FIRST, so we emulate using CASE

--- a/core/src/main/java/org/apache/calcite/sql/dialect/MysqlSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/MysqlSqlDialect.java
@@ -143,6 +143,10 @@ public class MysqlSqlDialect extends SqlDialect {
     return true;
   }
 
+  @Override public boolean requiresColumnsInMergeInsertClause() {
+    throw new UnsupportedOperationException();
+  }
+
   @Override public CalendarPolicy getCalendarPolicy() {
     return CalendarPolicy.SHIFT;
   }

--- a/core/src/main/java/org/apache/calcite/sql/dialect/NeoviewSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/NeoviewSqlDialect.java
@@ -31,4 +31,8 @@ public class NeoviewSqlDialect extends SqlDialect {
   public NeoviewSqlDialect(Context context) {
     super(context);
   }
+
+  @Override public boolean requiresColumnsInMergeInsertClause() {
+    throw new UnsupportedOperationException();
+  }
 }

--- a/core/src/main/java/org/apache/calcite/sql/dialect/OracleSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/OracleSqlDialect.java
@@ -78,6 +78,10 @@ public class OracleSqlDialect extends SqlDialect {
     return false;
   }
 
+  @Override public boolean requiresColumnsInMergeInsertClause() {
+    throw new UnsupportedOperationException();
+  }
+
   @Override public boolean supportsDataType(RelDataType type) {
     switch (type.getSqlTypeName()) {
     case BOOLEAN:

--- a/core/src/main/java/org/apache/calcite/sql/dialect/ParaccelSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/ParaccelSqlDialect.java
@@ -32,4 +32,8 @@ public class ParaccelSqlDialect extends SqlDialect {
   public ParaccelSqlDialect(Context context) {
     super(context);
   }
+
+  @Override public boolean requiresColumnsInMergeInsertClause() {
+    throw new UnsupportedOperationException();
+  }
 }

--- a/core/src/main/java/org/apache/calcite/sql/dialect/PhoenixSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/PhoenixSqlDialect.java
@@ -36,4 +36,8 @@ public class PhoenixSqlDialect extends SqlDialect {
   @Override public boolean supportsCharSet() {
     return false;
   }
+
+  @Override public boolean requiresColumnsInMergeInsertClause() {
+    throw new UnsupportedOperationException();
+  }
 }

--- a/core/src/main/java/org/apache/calcite/sql/dialect/PostgresqlSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/PostgresqlSqlDialect.java
@@ -74,6 +74,10 @@ public class PostgresqlSqlDialect extends SqlDialect {
     return false;
   }
 
+  @Override public boolean requiresColumnsInMergeInsertClause() {
+    throw new UnsupportedOperationException();
+  }
+
   @Override public @Nullable SqlNode getCastSpec(RelDataType type) {
     String castSpec;
     switch (type.getSqlTypeName()) {

--- a/core/src/main/java/org/apache/calcite/sql/dialect/PrestoSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/PrestoSqlDialect.java
@@ -60,6 +60,10 @@ public class PrestoSqlDialect extends SqlDialect {
     return true;
   }
 
+  @Override public boolean requiresColumnsInMergeInsertClause() {
+    throw new UnsupportedOperationException();
+  }
+
   @Override public void unparseOffsetFetch(SqlWriter writer, @Nullable SqlNode offset,
       @Nullable SqlNode fetch) {
     unparseUsingLimit(writer, offset, fetch);

--- a/core/src/main/java/org/apache/calcite/sql/dialect/RedshiftSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/RedshiftSqlDialect.java
@@ -45,4 +45,8 @@ public class RedshiftSqlDialect extends SqlDialect {
       @Nullable SqlNode fetch) {
     unparseFetchUsingLimit(writer, offset, fetch);
   }
+
+  @Override public boolean requiresColumnsInMergeInsertClause() {
+    throw new UnsupportedOperationException();
+  }
 }

--- a/core/src/main/java/org/apache/calcite/sql/dialect/SparkSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/SparkSqlDialect.java
@@ -194,6 +194,10 @@ public class SparkSqlDialect extends SqlDialect {
     return true;
   }
 
+  @Override public boolean requiresColumnsInMergeInsertClause() {
+    return true;
+  }
+
   @Override public void unparseOffsetFetch(SqlWriter writer, @Nullable SqlNode offset,
       @Nullable SqlNode fetch) {
     unparseFetchUsingLimit(writer, offset, fetch);

--- a/core/src/main/java/org/apache/calcite/sql/dialect/SybaseSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/SybaseSqlDialect.java
@@ -38,6 +38,10 @@ public class SybaseSqlDialect extends SqlDialect {
     super(context);
   }
 
+  @Override public boolean requiresColumnsInMergeInsertClause() {
+    throw new UnsupportedOperationException();
+  }
+
   @Override public void unparseOffsetFetch(SqlWriter writer, @Nullable SqlNode offset,
       @Nullable SqlNode fetch) {
     // No-op; see unparseTopN.

--- a/core/src/main/java/org/apache/calcite/sql/dialect/VerticaSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/VerticaSqlDialect.java
@@ -38,4 +38,8 @@ public class VerticaSqlDialect extends SqlDialect {
   @Override public boolean supportsNestedAggregations() {
     return false;
   }
+
+  @Override public boolean requiresColumnsInMergeInsertClause() {
+    throw new UnsupportedOperationException();
+  }
 }


### PR DESCRIPTION
requiresColumnsInMergeInsertClause() is added in SqlDialect and is defaulted to false, 
bq, hive, netezza, snowflake, teradata -> default to false
spark -> true
others -> throw UnsupportedOperationException