### PR TITLE
Support for TRIM, POSITION, CONCAT pipe operator, RAISE_ERROR in spark.

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/dialect/SparkSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/SparkSqlDialect.java
@@ -62,6 +62,7 @@ import static org.apache.calcite.sql.fun.SqlLibraryOperators.DATE_FORMAT;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.FROM_UNIXTIME;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.SPLIT;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.UNIX_TIMESTAMP;
+import static org.apache.calcite.sql.fun.SqlLibraryOperators.RAISE_ERROR;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.CAST;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.FLOOR;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.MINUS;
@@ -523,6 +524,10 @@ public class SparkSqlDialect extends SqlDialect {
       break;
     case "DATE_DIFF":
       unparseDateDiff(writer, call, leftPrec, rightPrec);
+      break;
+    case "ERROR":
+      SqlCall errorCall = RAISE_ERROR.createCall(SqlParserPos.ZERO, (SqlNode) call.operand(0));
+      super.unparseCall(writer, errorCall, leftPrec, rightPrec);
       break;
     default:
       super.unparseCall(writer, call, leftPrec, rightPrec);

--- a/core/src/main/java/org/apache/calcite/sql/dialect/SparkSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/SparkSqlDialect.java
@@ -42,17 +42,13 @@ import org.apache.calcite.sql.SqlSyntax;
 import org.apache.calcite.sql.SqlUtil;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.fun.SqlFloorFunction;
-import org.apache.calcite.sql.fun.SqlLibraryOperators;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.parser.CurrentTimestampHandler;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.BasicSqlType;
 import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.sql.type.SqlTypeName;
-import org.apache.calcite.util.CastCallBuilder;
-import org.apache.calcite.util.PaddingFunctionUtil;
-import org.apache.calcite.util.TimeString;
-import org.apache.calcite.util.ToNumberUtils;
+import org.apache.calcite.util.*;
 import org.apache.calcite.util.interval.SparkDateTimestampInterval;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -61,33 +57,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
 
-import static org.apache.calcite.sql.SqlDateTimeFormat.ABBREVIATEDDAYOFWEEK;
-import static org.apache.calcite.sql.SqlDateTimeFormat.ABBREVIATEDMONTH;
-import static org.apache.calcite.sql.SqlDateTimeFormat.AMPM;
-import static org.apache.calcite.sql.SqlDateTimeFormat.DAYOFMONTH;
-import static org.apache.calcite.sql.SqlDateTimeFormat.DAYOFWEEK;
-import static org.apache.calcite.sql.SqlDateTimeFormat.DAYOFYEAR;
-import static org.apache.calcite.sql.SqlDateTimeFormat.DDMMYY;
-import static org.apache.calcite.sql.SqlDateTimeFormat.DDMMYYYY;
-import static org.apache.calcite.sql.SqlDateTimeFormat.FOURDIGITYEAR;
-import static org.apache.calcite.sql.SqlDateTimeFormat.FRACTIONFIVE;
-import static org.apache.calcite.sql.SqlDateTimeFormat.FRACTIONFOUR;
-import static org.apache.calcite.sql.SqlDateTimeFormat.FRACTIONONE;
-import static org.apache.calcite.sql.SqlDateTimeFormat.FRACTIONSIX;
-import static org.apache.calcite.sql.SqlDateTimeFormat.FRACTIONTHREE;
-import static org.apache.calcite.sql.SqlDateTimeFormat.FRACTIONTWO;
-import static org.apache.calcite.sql.SqlDateTimeFormat.HOUR;
-import static org.apache.calcite.sql.SqlDateTimeFormat.MINUTE;
-import static org.apache.calcite.sql.SqlDateTimeFormat.MMDDYY;
-import static org.apache.calcite.sql.SqlDateTimeFormat.MMDDYYYY;
-import static org.apache.calcite.sql.SqlDateTimeFormat.MONTHNAME;
-import static org.apache.calcite.sql.SqlDateTimeFormat.NUMERICMONTH;
-import static org.apache.calcite.sql.SqlDateTimeFormat.SECOND;
-import static org.apache.calcite.sql.SqlDateTimeFormat.TIMEZONE;
-import static org.apache.calcite.sql.SqlDateTimeFormat.TWENTYFOURHOUR;
-import static org.apache.calcite.sql.SqlDateTimeFormat.TWODIGITYEAR;
-import static org.apache.calcite.sql.SqlDateTimeFormat.YYMMDD;
-import static org.apache.calcite.sql.SqlDateTimeFormat.YYYYMMDD;
+import static org.apache.calcite.sql.SqlDateTimeFormat.*;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.DATE_FORMAT;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.FROM_UNIXTIME;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.SPLIT;
@@ -98,7 +68,6 @@ import static org.apache.calcite.sql.fun.SqlStdOperatorTable.MINUS;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.MULTIPLY;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.PLUS;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.RAND;
-import static org.apache.calcite.util.RelToSqlConverterUtil.unparseHiveTrim;
 
 /**
  * A <code>SqlDialect</code> implementation for the APACHE SPARK database.
@@ -139,14 +108,18 @@ public class SparkSqlDialect extends SqlDialect {
         put(HOUR, "hh");
         put(MINUTE, "mm");
         put(SECOND, "ss");
-        put(FRACTIONONE, "s");
-        put(FRACTIONTWO, "ss");
-        put(FRACTIONTHREE, "sss");
-        put(FRACTIONFOUR, "ssss");
-        put(FRACTIONFIVE, "sssss");
-        put(FRACTIONSIX, "ssssss");
-        put(AMPM, "aa");
+        put(FRACTIONONE, "S");
+        put(FRACTIONTWO, "SS");
+        put(FRACTIONTHREE, "SSS");
+        put(FRACTIONFOUR, "SSSS");
+        put(FRACTIONFIVE, "SSSSS");
+        put(FRACTIONSIX, "SSSSSS");
+        put(AMPM, "a");
         put(TIMEZONE, "z");
+        put(POST_MERIDIAN_INDICATOR, "a");
+        put(ANTE_MERIDIAN_INDICATOR, "a");
+        put(POST_MERIDIAN_INDICATOR1, "a");
+        put(ANTE_MERIDIAN_INDICATOR1, "a");
       }};
 
   /**
@@ -216,12 +189,11 @@ public class SparkSqlDialect extends SqlDialect {
     case DATE:
       switch (call.getOperands().get(1).getType().getSqlTypeName()) {
       case INTERVAL_DAY:
-        if (call.op.kind == SqlKind.MINUS) {
-          return SqlLibraryOperators.DATE_SUB;
-        }
-        return SqlLibraryOperators.DATE_ADD;
       case INTERVAL_MONTH:
-        return SqlLibraryOperators.ADD_MONTHS;
+        if (call.op.kind == SqlKind.MINUS) {
+          return MINUS;
+        }
+        return PLUS;
       }
     default:
       return super.getTargetFunc(call);
@@ -254,18 +226,6 @@ public class SparkSqlDialect extends SqlDialect {
       SqlUtil.unparseFunctionSyntax(SPARKSQL_SUBSTRING, writer, call, false);
     } else {
       switch (call.getKind()) {
-
-      case POSITION:
-        final SqlWriter.Frame frame = writer.startFunCall("INSTR");
-        writer.sep(",");
-        call.operand(1).unparse(writer, leftPrec, rightPrec);
-        writer.sep(",");
-        call.operand(0).unparse(writer, leftPrec, rightPrec);
-        if (3 == call.operandCount()) {
-          throw new RuntimeException("3rd operand Not Supported for Function INSTR in Hive");
-        }
-        writer.endFunCall(frame);
-        break;
       case MOD:
         SqlOperator op = SqlStdOperatorTable.PERCENT_REMAINDER;
         SqlSyntax.BINARY.unparse(writer, op, call, leftPrec, rightPrec);
@@ -289,14 +249,6 @@ public class SparkSqlDialect extends SqlDialect {
         }
         writer.endList(arrayFrame);
         break;
-      case CONCAT:
-        final SqlWriter.Frame concatFrame = writer.startFunCall("CONCAT");
-        for (SqlNode operand : call.getOperandList()) {
-          writer.sep(",");
-          operand.unparse(writer, leftPrec, rightPrec);
-        }
-        writer.endFunCall(concatFrame);
-        break;
       case DIVIDE_INTEGER:
         unparseDivideInteger(writer, call, leftPrec, rightPrec);
         break;
@@ -312,9 +264,6 @@ public class SparkSqlDialect extends SqlDialect {
         SqlCall call2 = SqlFloorFunction.replaceTimeUnitOperand(call, timeUnit.name(),
             timeUnitNode.getParserPosition());
         SqlFloorFunction.unparseDatetimeFunction(writer, call2, "DATE_TRUNC", false);
-        break;
-      case TRIM:
-        unparseHiveTrim(writer, call, leftPrec, rightPrec);
         break;
       case FORMAT:
         unparseFormat(writer, call, leftPrec, rightPrec);

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -1338,4 +1338,13 @@ public abstract class SqlLibraryOperators {
           null,
           OperandTypes.family(SqlTypeFamily.DATE,
           SqlTypeFamily.STRING), SqlFunctionCategory.SYSTEM);
+
+  @LibraryOperator(libraries = {SPARK})
+  public static final SqlFunction RAISE_ERROR =
+      new SqlFunction("RAISE_ERROR",
+          SqlKind.OTHER_FUNCTION,
+          null,
+          null,
+          OperandTypes.STRING,
+          SqlFunctionCategory.SYSTEM);
 }

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -1664,11 +1664,13 @@ class RelToSqlConverterTest {
         + "from \"foodmart\".\"reserve_employee\"";
     final String expected = "SELECT TRIM(' str ')\n"
         + "FROM foodmart.reserve_employee";
+    final String expectedSpark = "SELECT TRIM(BOTH ' ' FROM ' str ')\nFROM foodmart" +
+        ".reserve_employee";
     sql(query)
         .withHive()
         .ok(expected)
         .withSpark()
-      .ok(expected)
+      .ok(expectedSpark)
       .withBigQuery()
         .ok(expected);
   }
@@ -1678,11 +1680,13 @@ class RelToSqlConverterTest {
         + "from \"foodmart\".\"reserve_employee\"";
     final String expected = "SELECT TRIM(' str ')\n"
         + "FROM foodmart.reserve_employee";
+    final String expectedSpark = "SELECT TRIM(BOTH ' ' FROM ' str ')\n" +
+        "FROM foodmart.reserve_employee";
     sql(query)
         .withHive()
         .ok(expected)
         .withSpark()
-      .ok(expected)
+      .ok(expectedSpark)
       .withBigQuery()
         .ok(expected);
   }
@@ -1692,11 +1696,13 @@ class RelToSqlConverterTest {
         + "from \"foodmart\".\"reserve_employee\"";
     final String expected = "SELECT LTRIM(' str ')\n"
         + "FROM foodmart.reserve_employee";
+    final String expectedSpark = "SELECT TRIM(LEADING ' ' FROM ' str ')\nFROM foodmart" +
+        ".reserve_employee";
     sql(query)
         .withHive()
         .ok(expected)
         .withSpark()
-      .ok(expected)
+      .ok(expectedSpark)
       .withBigQuery()
         .ok(expected);
   }
@@ -1707,11 +1713,13 @@ class RelToSqlConverterTest {
         + "from \"foodmart\".\"reserve_employee\"";
     final String expected = "SELECT RTRIM(' str ')\n"
         + "FROM foodmart.reserve_employee";
+    final String expectedSpark = "SELECT TRIM(TRAILING ' ' FROM ' str ')\nFROM foodmart" +
+        ".reserve_employee";
     sql(query)
         .withHive()
         .ok(expected)
         .withSpark()
-      .ok(expected)
+      .ok(expectedSpark)
       .withBigQuery()
         .ok(expected);
   }
@@ -1740,11 +1748,13 @@ class RelToSqlConverterTest {
         + "from \"foodmart\".\"reserve_employee\"";
     final String expected = "SELECT REGEXP_REPLACE('abcd', '^(a)*', '')\n"
         + "FROM foodmart.reserve_employee";
+    final String expectedSpark = "SELECT TRIM(LEADING 'a' FROM 'abcd')\nFROM foodmart" +
+        ".reserve_employee";
     sql(query)
         .withHive()
         .ok(expected)
         .withSpark()
-        .ok(expected);
+        .ok(expectedSpark);
   }
 
   @Test void testBqTrimWithBothChar() {
@@ -1762,11 +1772,13 @@ class RelToSqlConverterTest {
         + "from \"foodmart\".\"reserve_employee\"";
     final String expected = "SELECT REGEXP_REPLACE('abcda', '^(a)*|(a)*$', '')\n"
         + "FROM foodmart.reserve_employee";
+    final String expectedSpark = "SELECT TRIM(BOTH 'a' FROM 'abcda')\n" +
+        "FROM foodmart.reserve_employee";
     sql(query)
         .withHive()
         .ok(expected)
         .withSpark()
-        .ok(expected);
+        .ok(expectedSpark);
   }
 
   @Test void testHiveBqTrimWithTailingChar() {
@@ -1786,11 +1798,13 @@ class RelToSqlConverterTest {
         + "FROM foodmart.reserve_employee";
     final String expectedSnowFlake = "SELECT TRIM(\"full_name\")\n"
         + "FROM \"foodmart\".\"reserve_employee\"";
+    final String expectedSpark = "SELECT TRIM(BOTH ' ' FROM full_name)\nFROM foodmart" +
+        ".reserve_employee";
     sql(query)
         .withHive()
         .ok(expected)
         .withSpark()
-        .ok(expected)
+        .ok(expectedSpark)
         .withBigQuery()
         .ok(expected)
         .withSnowflake()
@@ -1802,6 +1816,7 @@ class RelToSqlConverterTest {
         + "from \"foodmart\".\"reserve_employee\"";
     final String expected = "SELECT TRIM(full_name)\n"
         + "FROM foodmart.reserve_employee";
+    final String expectedSpark = "SELECT TRIM(BOTH ' ' FROM full_name)\nFROM foodmart.reserve_employee";
     final String expectedSnowFlake = "SELECT TRIM(\"full_name\")\n"
         + "FROM \"foodmart\".\"reserve_employee\"";
     final String expectedMsSql = "SELECT TRIM(' ' FROM [full_name])\n"
@@ -1810,7 +1825,7 @@ class RelToSqlConverterTest {
         .withHive()
         .ok(expected)
         .withSpark()
-        .ok(expected)
+        .ok(expectedSpark)
         .withBigQuery()
         .ok(expected)
         .withSnowflake()
@@ -1824,6 +1839,8 @@ class RelToSqlConverterTest {
         + "from \"foodmart\".\"reserve_employee\"";
     final String expected = "SELECT LTRIM(' str ')\n"
         + "FROM foodmart.reserve_employee";
+    final String expectedSpark = "SELECT TRIM(LEADING ' ' FROM ' str ')\nFROM foodmart" +
+        ".reserve_employee";
     final String expectedSnowFlake = "SELECT LTRIM(' str ')\n"
               + "FROM \"foodmart\".\"reserve_employee\"";
     final String expectedMsSql = "SELECT LTRIM(' str ')\n"
@@ -1832,7 +1849,7 @@ class RelToSqlConverterTest {
         .withHive()
         .ok(expected)
         .withSpark()
-        .ok(expected)
+        .ok(expectedSpark)
         .withBigQuery()
         .ok(expected)
         .withSnowflake()
@@ -1846,6 +1863,8 @@ class RelToSqlConverterTest {
         + "from \"foodmart\".\"reserve_employee\"";
     final String expected = "SELECT RTRIM(' str ')\n"
         + "FROM foodmart.reserve_employee";
+    final String expectedSpark = "SELECT TRIM(TRAILING ' ' FROM ' str ')" +
+        "\nFROM foodmart.reserve_employee";
     final String expectedSnowFlake = "SELECT RTRIM(' str ')\n"
         + "FROM \"foodmart\".\"reserve_employee\"";
     final String expectedMsSql = "SELECT RTRIM(' str ')\n"
@@ -1854,7 +1873,7 @@ class RelToSqlConverterTest {
         .withHive()
         .ok(expected)
         .withSpark()
-        .ok(expected)
+        .ok(expectedSpark)
         .withBigQuery()
         .ok(expected)
         .withSnowflake()
@@ -1868,6 +1887,8 @@ class RelToSqlConverterTest {
         + "from \"foodmart\".\"reserve_employee\"";
     final String expected = "SELECT LTRIM(first_name, 'A')\n"
         + "FROM foodmart.reserve_employee";
+    final String expectedSpark = "SELECT TRIM(LEADING 'A' FROM first_name)\nFROM foodmart" +
+        ".reserve_employee";
     final String expectedHS = "SELECT REGEXP_REPLACE(first_name, '^(A)*', '')\n"
         + "FROM foodmart.reserve_employee";
     final String expectedSnowFlake = "SELECT LTRIM(\"first_name\", 'A')\n"
@@ -1876,7 +1897,7 @@ class RelToSqlConverterTest {
         .withHive()
         .ok(expectedHS)
         .withSpark()
-        .ok(expectedHS)
+        .ok(expectedSpark)
         .withBigQuery()
         .ok(expected)
         .withSnowflake()
@@ -1888,6 +1909,8 @@ class RelToSqlConverterTest {
         + "from \"foodmart\".\"reserve_employee\"";
     final String expected = "SELECT RTRIM('AABCAADCAA', 'A')\n"
         + "FROM foodmart.reserve_employee";
+    final String expectedSpark = "SELECT TRIM(TRAILING 'A' FROM 'AABCAADCAA')\nFROM foodmart" +
+        ".reserve_employee";
     final String expectedHS = "SELECT REGEXP_REPLACE('AABCAADCAA', '(A)*$', '')\n"
         + "FROM foodmart.reserve_employee";
     final String expectedSnowFlake = "SELECT RTRIM('AABCAADCAA', 'A')\n"
@@ -1896,7 +1919,7 @@ class RelToSqlConverterTest {
         .withHive()
         .ok(expectedHS)
         .withSpark()
-        .ok(expectedHS)
+        .ok(expectedSpark)
         .withBigQuery()
         .ok(expected)
         .withSnowflake()
@@ -1908,6 +1931,8 @@ class RelToSqlConverterTest {
         + "from \"foodmart\".\"reserve_employee\"";
     final String expected = "SELECT TRIM('AABCAADCAA', 'A')\n"
         + "FROM foodmart.reserve_employee";
+    final String expectedSpark = "SELECT TRIM(BOTH 'A' FROM 'AABCAADCAA')\nFROM foodmart" +
+        ".reserve_employee";
     final String expectedHS = "SELECT REGEXP_REPLACE('AABCAADCAA', '^(A)*|(A)*$', '')\n"
         + "FROM foodmart.reserve_employee";
     final String expectedSnowFlake = "SELECT TRIM('AABCAADCAA', 'A')\n"
@@ -1916,7 +1941,7 @@ class RelToSqlConverterTest {
         .withHive()
         .ok(expectedHS)
         .withSpark()
-        .ok(expectedHS)
+        .ok(expectedSpark)
         .withBigQuery()
         .ok(expected)
         .withSnowflake()
@@ -1931,13 +1956,15 @@ class RelToSqlConverterTest {
     final String expectedHS =
         "SELECT REGEXP_REPLACE('A$@*AABCA$@*AADCAA$@*', '^(A\\$\\@\\*)*', '')\n"
             + "FROM foodmart.reserve_employee";
+    final String expectedSpark = "SELECT TRIM(LEADING 'A$@*' FROM 'A$@*AABCA$@*AADCAA$@*')\nFROM" +
+        " foodmart.reserve_employee";
     final String expectedSnowFlake = "SELECT LTRIM('A$@*AABCA$@*AADCAA$@*', 'A$@*')\n"
         + "FROM \"foodmart\".\"reserve_employee\"";
     sql(query)
         .withHive()
         .ok(expectedHS)
         .withSpark()
-        .ok(expectedHS)
+        .ok(expectedSpark)
         .withBigQuery()
         .ok(expected)
         .withSnowflake()
@@ -1952,13 +1979,15 @@ class RelToSqlConverterTest {
     final String expectedHS =
         "SELECT REGEXP_REPLACE('$A@*AABC$@*AADCAA$A@*', '(\\$A\\@\\*)*$', '')\n"
             + "FROM foodmart.reserve_employee";
+    final String expectedSpark = "SELECT TRIM(TRAILING '$A@*' FROM '$A@*AABC$@*AADCAA$A@*')\n" +
+        "FROM foodmart.reserve_employee";
     final String expectedSnowFlake = "SELECT RTRIM('$A@*AABC$@*AADCAA$A@*', '$A@*')\n"
         + "FROM \"foodmart\".\"reserve_employee\"";
     sql(query)
         .withHive()
         .ok(expectedHS)
         .withSpark()
-        .ok(expectedHS)
+        .ok(expectedSpark)
         .withBigQuery()
         .ok(expected)
         .withSnowflake()
@@ -1975,13 +2004,15 @@ class RelToSqlConverterTest {
         "SELECT REGEXP_REPLACE('$@*AABC$@*AADCAA$@*A',"
             + " '^(\\$\\@\\*A)*|(\\$\\@\\*A)*$', '')\n"
             + "FROM foodmart.reserve_employee";
+    final String expectedSpark = "SELECT TRIM(BOTH '$@*A' FROM '$@*AABC$@*AADCAA$@*A')\nFROM " +
+        "foodmart.reserve_employee";
     final String expectedSnowFlake = "SELECT TRIM('$@*AABC$@*AADCAA$@*A', '$@*A')\n"
               + "FROM \"foodmart\".\"reserve_employee\"";
     sql(query)
         .withHive()
         .ok(expectedHS)
         .withSpark()
-        .ok(expectedHS)
+        .ok(expectedSpark)
         .withBigQuery()
         .ok(expected)
         .withSnowflake()
@@ -1996,9 +2027,8 @@ class RelToSqlConverterTest {
     final String expectedHS =
         "SELECT TRIM(SUBSTRING(full_name, 2, 3))\n"
             + "FROM foodmart.reserve_employee";
-    final String expectedSpark =
-        "SELECT TRIM(SUBSTRING(full_name, 2, 3))\n"
-            + "FROM foodmart.reserve_employee";
+    final String expectedSpark = "SELECT TRIM(BOTH ' ' FROM SUBSTRING(full_name, 2, 3))" +
+        "\nFROM foodmart.reserve_employee";
     final String expectedSnowFlake = "SELECT TRIM(SUBSTR(\"full_name\", 2, 3))\n"
         + "FROM \"foodmart\".\"reserve_employee\"";
 
@@ -2018,11 +2048,13 @@ class RelToSqlConverterTest {
         + "from \"foodmart\".\"reserve_employee\"";
     final String expected = "SELECT REGEXP_REPLACE('abcd', '(a)*$', '')\n"
         + "FROM foodmart.reserve_employee";
+    final String expectedSpark = "SELECT TRIM(TRAILING 'a' FROM 'abcd')\nFROM foodmart" +
+        ".reserve_employee";
     sql(query)
         .withHive()
         .ok(expected)
         .withSpark()
-        .ok(expected);
+        .ok(expectedSpark);
   }
 
   @Test void testBqTrimWithBothSpecialCharacter() {
@@ -2041,11 +2073,13 @@ class RelToSqlConverterTest {
     final String expected = "SELECT REGEXP_REPLACE('$@*AABC$@*AADCAA$@*A',"
         + " '^(\\$\\@\\*A)*|(\\$\\@\\*A)*$', '')\n"
         + "FROM foodmart.reserve_employee";
+    final String expectedSpark = "SELECT TRIM(BOTH '$@*A' FROM '$@*AABC$@*AADCAA$@*A')\n"
+        + "FROM foodmart.reserve_employee";
     sql(query)
         .withHive()
         .ok(expected)
         .withSpark()
-        .ok(expected);
+        .ok(expectedSpark);
   }
 
   /** Test case for
@@ -5953,9 +5987,8 @@ class RelToSqlConverterTest {
     final String expectedBiqQuery = "SELECT CAST(FORMAT_TIMESTAMP('%F %H:%M:%E6S', "
         + "CURRENT_DATETIME()) AS DATETIME) AS CT\n"
         + "FROM scott.EMP";
-    final String expectedSpark = "SELECT CAST(DATE_FORMAT(CURRENT_TIMESTAMP, 'yyyy-MM-dd HH:mm:ss"
-        + ".ssssss') AS TIMESTAMP) CT\n"
-        + "FROM scott.EMP";
+    final String expectedSpark = "SELECT CAST(DATE_FORMAT(CURRENT_TIMESTAMP, 'yyyy-MM-dd HH:mm:ss" +
+        ".SSSSSS') AS TIMESTAMP) CT\nFROM scott.EMP";
     final String expectedHive = "SELECT CAST(DATE_FORMAT(CURRENT_TIMESTAMP, 'yyyy-MM-dd HH:mm:ss"
         + ".ssssss') AS TIMESTAMP) CT\n"
         + "FROM scott.EMP";
@@ -6001,8 +6034,7 @@ class RelToSqlConverterTest {
     String query = "select \"birth_date\" - INTERVAL -'1' MONTH from \"employee\"";
     final String expectedHive = "SELECT ADD_MONTHS(birth_date, -1)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT ADD_MONTHS(birth_date, -1)\n"
-        + "FROM foodmart.employee";
+    final String expectedSpark = "SELECT birth_date - INTERVAL '1' MONTH\nFROM foodmart.employee";
     final String expectedBigQuery = "SELECT DATE_SUB(birth_date, INTERVAL -1 MONTH)\n"
         + "FROM foodmart.employee";
     sql(query)
@@ -6018,8 +6050,8 @@ class RelToSqlConverterTest {
     String query = "select \"birth_date\" + -10 * INTERVAL '1' MONTH from \"employee\"";
     final String expectedHive = "SELECT ADD_MONTHS(birth_date, -10)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT ADD_MONTHS(birth_date, -10)\n"
-        + "FROM foodmart.employee";
+    final String expectedSpark = "SELECT birth_date + -10 * INTERVAL '1' MONTH\nFROM foodmart" +
+        ".employee";
     final String expectedBigQuery = "SELECT DATE_ADD(birth_date, INTERVAL -10 MONTH)\n"
         + "FROM foodmart.employee";
     sql(query)
@@ -6046,8 +6078,8 @@ class RelToSqlConverterTest {
     String query = "select \"birth_date\" +  \"store_id\" * INTERVAL '10' MONTH from \"employee\"";
     final String expectedHive = "SELECT ADD_MONTHS(birth_date, store_id * 10)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT ADD_MONTHS(birth_date, store_id * 10)\n"
-        + "FROM foodmart.employee";
+    final String expectedSpark = "SELECT birth_date + store_id * INTERVAL '10' MONTH\nFROM " +
+        "foodmart.employee";
     final String expectedBigQuery = "SELECT DATE_ADD(birth_date, INTERVAL store_id * 10 MONTH)\n"
         + "FROM foodmart.employee";
     sql(query)
@@ -6063,8 +6095,8 @@ class RelToSqlConverterTest {
     String query = "select \"birth_date\" + 10 * INTERVAL '2' MONTH from \"employee\"";
     final String expectedHive = "SELECT ADD_MONTHS(birth_date, 10 * 2)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT ADD_MONTHS(birth_date, 10 * 2)\n"
-        + "FROM foodmart.employee";
+    final String expectedSpark = "SELECT birth_date + 10 * INTERVAL '2' MONTH\nFROM foodmart" +
+        ".employee";
     final String expectedBigQuery = "SELECT DATE_ADD(birth_date, INTERVAL 10 * 2 MONTH)\n"
         + "FROM foodmart.employee";
     sql(query)
@@ -6080,8 +6112,7 @@ class RelToSqlConverterTest {
     String query = "select \"birth_date\" + INTERVAL '1' DAY from \"employee\"";
     final String expectedHive = "SELECT CAST(DATE_ADD(birth_date, 1) AS DATE)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT DATE_ADD(birth_date, 1)\n"
-        + "FROM foodmart.employee";
+    final String expectedSpark = "SELECT birth_date + INTERVAL '1' DAY\nFROM foodmart.employee";
     final String expectedBigQuery = "SELECT DATE_ADD(birth_date, INTERVAL 1 DAY)\n"
         + "FROM foodmart.employee";
     final String expectedSnowflake = "SELECT DATEADD(DAY, 1, \"birth_date\")\n"
@@ -6101,8 +6132,7 @@ class RelToSqlConverterTest {
     String query = "select \"birth_date\" - INTERVAL '1' DAY from \"employee\"";
     final String expectedHive = "SELECT CAST(DATE_SUB(birth_date, 1) AS DATE)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT DATE_SUB(birth_date, 1)\n"
-        + "FROM foodmart.employee";
+    final String expectedSpark = "SELECT birth_date - INTERVAL '1' DAY\nFROM foodmart.employee";
     final String expectedBigQuery = "SELECT DATE_SUB(birth_date, INTERVAL 1 DAY)\n"
         + "FROM foodmart.employee";
     final String expectedSnowflake = "SELECT DATEADD(DAY, -1, \"birth_date\")\n"
@@ -6122,8 +6152,8 @@ class RelToSqlConverterTest {
     String query = "select DATE'2018-01-01' + INTERVAL '1' DAY from \"employee\"";
     final String expectedHive = "SELECT CAST(DATE_ADD(DATE '2018-01-01', 1) AS DATE)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT DATE_ADD(DATE '2018-01-01', 1)\n"
-        + "FROM foodmart.employee";
+    final String expectedSpark = "SELECT DATE '2018-01-01' + INTERVAL '1' DAY\nFROM foodmart" +
+        ".employee";
     final String expectedBigQuery = "SELECT DATE_ADD(DATE '2018-01-01', INTERVAL 1 DAY)\n"
         + "FROM foodmart.employee";
     final String expectedSnowflake = "SELECT DATEADD(DAY, 1, DATE '2018-01-01')\n"
@@ -6143,8 +6173,8 @@ class RelToSqlConverterTest {
     String query = "select DATE'2018-01-01' - INTERVAL '1' DAY from \"employee\"";
     final String expectedHive = "SELECT CAST(DATE_SUB(DATE '2018-01-01', 1) AS DATE)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT DATE_SUB(DATE '2018-01-01', 1)\n"
-        + "FROM foodmart.employee";
+    final String expectedSpark = "SELECT DATE '2018-01-01' - INTERVAL '1' DAY\n" +
+        "FROM foodmart.employee";
     final String expectedBigQuery = "SELECT DATE_SUB(DATE '2018-01-01', INTERVAL 1 DAY)\n"
         + "FROM foodmart.employee";
     final String expectedSnowflake = "SELECT DATEADD(DAY, -1, DATE '2018-01-01')\n"
@@ -6164,8 +6194,7 @@ class RelToSqlConverterTest {
     String query = "select \"birth_date\" + INTERVAL '2' day from \"employee\"";
     final String expectedHive = "SELECT CAST(DATE_ADD(birth_date, 2) AS DATE)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT DATE_ADD(birth_date, 2)\n"
-        + "FROM foodmart.employee";
+    final String expectedSpark = "SELECT birth_date + INTERVAL '2' DAY\nFROM foodmart.employee";
     final String expectedBigQuery = "SELECT DATE_ADD(birth_date, INTERVAL 2 DAY)\n"
         + "FROM foodmart.employee";
     final String expectedSnowflake = "SELECT DATEADD(DAY, 2, \"birth_date\")\n"
@@ -6217,8 +6246,8 @@ class RelToSqlConverterTest {
     String query = "select \"birth_date\" - INTERVAL '2' day from \"employee\"";
     final String expectedHive = "SELECT CAST(DATE_SUB(birth_date, 2) AS DATE)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT DATE_SUB(birth_date, 2)\n"
-        + "FROM foodmart.employee";
+    final String expectedSpark = "SELECT birth_date - INTERVAL '2' DAY" +
+        "\nFROM foodmart.employee";
     final String expectedBigQuery = "SELECT DATE_SUB(birth_date, INTERVAL 2 DAY)\n"
         + "FROM foodmart.employee";
     final String expectedSnowflake = "SELECT DATEADD(DAY, -2, \"birth_date\")\n"
@@ -6238,8 +6267,8 @@ class RelToSqlConverterTest {
     String query = "select \"birth_date\" + \"store_id\" * INTERVAL '1' DAY from \"employee\"";
     final String expectedHive = "SELECT CAST(DATE_ADD(birth_date, store_id) AS DATE)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT DATE_ADD(birth_date, store_id)\n"
-        + "FROM foodmart.employee";
+    final String expectedSpark = "SELECT birth_date + store_id * INTERVAL '1' DAY" +
+        "\nFROM foodmart.employee";
     final String expectedBigQuery = "SELECT DATE_ADD(birth_date, INTERVAL store_id DAY)\n"
         + "FROM foodmart.employee";
     final String expectedSnowflake = "SELECT (\"birth_date\" + \"store_id\")\n"
@@ -6259,8 +6288,8 @@ class RelToSqlConverterTest {
     String query = "select \"birth_date\" +  INTERVAL '1' DAY * \"store_id\" from \"employee\"";
     final String expectedHive = "SELECT CAST(DATE_ADD(birth_date, store_id) AS DATE)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT DATE_ADD(birth_date, store_id)\n"
-        + "FROM foodmart.employee";
+    final String expectedSpark = "SELECT birth_date + INTERVAL '1' DAY * store_id\nFROM foodmart" +
+        ".employee";
     final String expectedBigQuery = "SELECT DATE_ADD(birth_date, INTERVAL store_id DAY)\n"
         + "FROM foodmart.employee";
     final String expectedSnowflake = "SELECT DATEADD(DAY, '1' * \"store_id\", \"birth_date\")\n"
@@ -6280,8 +6309,7 @@ class RelToSqlConverterTest {
     String query = "select \"birth_date\" +  INTERVAL '1' DAY * 10 from \"employee\"";
     final String expectedHive = "SELECT CAST(DATE_ADD(birth_date, 10) AS DATE)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT DATE_ADD(birth_date, 10)\n"
-        + "FROM foodmart.employee";
+    final String expectedSpark = "SELECT birth_date + INTERVAL '1' DAY * 10\nFROM foodmart.employee";
     final String expectedBigQuery = "SELECT DATE_ADD(birth_date, INTERVAL 10 DAY)\n"
         + "FROM foodmart.employee";
     final String expectedSnowflake = "SELECT DATEADD(DAY, '1' * 10, \"birth_date\")\n"
@@ -6301,8 +6329,8 @@ class RelToSqlConverterTest {
     String query = "select \"birth_date\" - \"store_id\" * INTERVAL '1' DAY from \"employee\"";
     final String expectedHive = "SELECT CAST(DATE_SUB(birth_date, store_id) AS DATE)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT DATE_SUB(birth_date, store_id)\n"
-        + "FROM foodmart.employee";
+    final String expectedSpark = "SELECT birth_date - store_id * INTERVAL '1' DAY" +
+        "\nFROM foodmart.employee";
     final String expectedBigQuery = "SELECT DATE_SUB(birth_date, INTERVAL store_id DAY)\n"
         + "FROM foodmart.employee";
     final String expectedSnowflake = "SELECT (\"birth_date\" - \"store_id\")\n"
@@ -6322,8 +6350,8 @@ class RelToSqlConverterTest {
     String query = "select DATE'2018-01-01' + \"store_id\" * INTERVAL '1' DAY from \"employee\"";
     final String expectedHive = "SELECT CAST(DATE_ADD(DATE '2018-01-01', store_id) AS DATE)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT DATE_ADD(DATE '2018-01-01', store_id)\n"
-        + "FROM foodmart.employee";
+    final String expectedSpark = "SELECT DATE '2018-01-01' + store_id * INTERVAL '1' DAY\nFROM " +
+        "foodmart.employee";
     final String expectedBigQuery = "SELECT DATE_ADD(DATE '2018-01-01', INTERVAL store_id DAY)\n"
         + "FROM foodmart.employee";
     final String expectedSnowflake = "SELECT (DATE '2018-01-01' + \"store_id\")\n"
@@ -6343,8 +6371,8 @@ class RelToSqlConverterTest {
     String query = "select \"birth_date\" + \"store_id\" *11 * INTERVAL '1' DAY from \"employee\"";
     final String expectedHive = "SELECT CAST(DATE_ADD(birth_date, store_id * 11) AS DATE)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT DATE_ADD(birth_date, store_id * 11)\n"
-        + "FROM foodmart.employee";
+    final String expectedSpark = "SELECT birth_date + store_id * 11 * INTERVAL '1' DAY\nFROM " +
+        "foodmart.employee";
     final String expectedBigQuery = "SELECT DATE_ADD(birth_date, INTERVAL store_id * 11 DAY)\n"
         + "FROM foodmart.employee";
     final String expectedSnowflake = "SELECT (\"birth_date\" + \"store_id\" * 11)\n"
@@ -6364,8 +6392,8 @@ class RelToSqlConverterTest {
     String query = "select \"birth_date\" + \"store_id\"  * INTERVAL '11' DAY from \"employee\"";
     final String expectedHive = "SELECT CAST(DATE_ADD(birth_date, store_id * 11) AS DATE)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT DATE_ADD(birth_date, store_id * 11)\n"
-        + "FROM foodmart.employee";
+    final String expectedSpark = "SELECT birth_date + store_id * INTERVAL '11' DAY\nFROM " +
+        "foodmart.employee";
     final String expectedBigQuery = "SELECT DATE_ADD(birth_date, INTERVAL store_id * 11 DAY)\n"
         + "FROM foodmart.employee";
     final String expectedSnowflake = "SELECT (\"birth_date\" + \"store_id\" * 11)\n"
@@ -6385,8 +6413,8 @@ class RelToSqlConverterTest {
     String query = "select \"birth_date\" - \"store_id\"  * INTERVAL '11' DAY from \"employee\"";
     final String expectedHive = "SELECT CAST(DATE_SUB(birth_date, store_id * 11) AS DATE)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT DATE_SUB(birth_date, store_id * 11)\n"
-        + "FROM foodmart.employee";
+    final String expectedSpark = "SELECT birth_date - store_id * INTERVAL '11' DAY\nFROM " +
+        "foodmart.employee";
     final String expectedBigQuery = "SELECT DATE_SUB(birth_date, INTERVAL store_id * 11 DAY)\n"
         + "FROM foodmart.employee";
     final String expectedSnowflake = "SELECT (\"birth_date\" - \"store_id\" * 11)\n"
@@ -6406,8 +6434,8 @@ class RelToSqlConverterTest {
     String query = "select \"birth_date\" + 10 * INTERVAL '2' DAY from \"employee\"";
     final String expectedHive = "SELECT CAST(DATE_ADD(birth_date, 10 * 2) AS DATE)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT DATE_ADD(birth_date, 10 * 2)\n"
-        + "FROM foodmart.employee";
+    final String expectedSpark = "SELECT birth_date + 10 * INTERVAL '2' DAY\n" +
+        "FROM foodmart.employee";
     final String expectedBigQuery = "SELECT DATE_ADD(birth_date, INTERVAL 10 * 2 DAY)\n"
         + "FROM foodmart.employee";
     final String expectedSnowflake = "SELECT (\"birth_date\" + 10 * 2)\n"
@@ -6427,8 +6455,7 @@ class RelToSqlConverterTest {
     String query = "select  INTERVAL '1' DAY + \"birth_date\" from \"employee\"";
     final String expectedHive = "SELECT CAST(DATE_ADD(birth_date, 1) AS DATE)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT DATE_ADD(birth_date, 1)\n"
-        + "FROM foodmart.employee";
+    final String expectedSpark = "SELECT birth_date + INTERVAL '1' DAY\nFROM foodmart.employee";
     final String expectedBigQuery = "SELECT DATE_ADD(birth_date, INTERVAL 1 DAY)\n"
         + "FROM foodmart.employee";
     final String expectedSnowflake = "SELECT DATEADD(DAY, 1, \"birth_date\")\n"
@@ -6602,11 +6629,13 @@ class RelToSqlConverterTest {
         + "FROM foodmart.employee";
     final String mssql = "SELECT CONCAT('foo', 'bar')\n"
             + "FROM [foodmart].[employee]";
+    final String expectedSpark = "SELECT 'foo' || 'bar'" +
+        "\nFROM foodmart.employee";
     sql(query)
         .withHive()
         .ok(expected)
         .withSpark()
-        .ok(expected)
+        .ok(expectedSpark)
         .withBigQuery()
         .ok(expected)
         .withMssql()
@@ -7858,7 +7887,8 @@ class RelToSqlConverterTest {
     final String expectedHive = "SELECT CAST(DATE_FORMAT(CAST(birth_date AS TIMESTAMP), "
         + "'yyyy-MM-dd HH:mm:ss.sss') AS TIMESTAMP)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = expectedHive;
+    final String expectedSpark = "SELECT CAST(DATE_FORMAT(CAST(birth_date AS TIMESTAMP), " +
+        "'yyyy-MM-dd HH:mm:ss.SSS') AS TIMESTAMP)\nFROM foodmart.employee";
     final String expectedBigQuery = "SELECT CAST(FORMAT_TIMESTAMP('%F %H:%M:%E3S', CAST"
         + "(birth_date AS DATETIME)) AS DATETIME)\n"
         + "FROM foodmart.employee";
@@ -7893,7 +7923,8 @@ class RelToSqlConverterTest {
     final String expectedHive = "SELECT SPLIT(DATE_FORMAT(hire_date, 'yyyy-MM-dd HH:mm:ss.sss'), "
         + "' ')[1]\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = expectedHive;
+    final String expectedSpark = "SELECT SPLIT(DATE_FORMAT(hire_date, 'yyyy-MM-dd HH:mm:ss.SSS')," +
+        " ' ')[1]\nFROM foodmart.employee";
     final String expectedBigQuery = "SELECT CAST(FORMAT_TIME('%H:%M:%E3S', CAST(hire_date AS TIME))"
         + " AS TIME)\n"
         + "FROM foodmart.employee";
@@ -7911,7 +7942,8 @@ class RelToSqlConverterTest {
         + "FROM \"foodmart\".\"employee\"";
     final String expectedHive = "SELECT CONCAT('12:00', ':05')\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = expectedHive;
+    final String expectedSpark = "SELECT '12:00' || ':05'\n"
+        + "FROM foodmart.employee";
     final String expectedBigQuery = "SELECT CAST(FORMAT_TIME('%H:%M:%E3S', CAST(CONCAT('12:00', "
         + "':05') AS TIME)) AS TIME)\n"
         + "FROM foodmart.employee";
@@ -8009,11 +8041,12 @@ class RelToSqlConverterTest {
     final String expectedSql = "SELECT FORMAT_TIMESTAMP('YYYY-MM-DD HH:MI:SS.S(5)', \"HIREDATE\") "
         + "AS \"FD\"\n"
         + "FROM \"scott\".\"EMP\"";
+    final String expectedSpark = "SELECT DATE_FORMAT(HIREDATE, 'yyyy-MM-dd hh:mm:ss.SSSSS') " +
+        "FD\nFROM scott.EMP";
     final String expectedBiqQuery = "SELECT FORMAT_TIMESTAMP('%F %I:%M:%E5S', HIREDATE) AS FD\n"
         + "FROM scott.EMP";
     final String expectedHive = "SELECT DATE_FORMAT(HIREDATE, 'yyyy-MM-dd hh:mm:ss.sssss') FD\n"
         + "FROM scott.EMP";
-    final String expectedSpark = expectedHive;
     assertThat(toSql(root, DatabaseProduct.CALCITE.getDialect()), isLinux(expectedSql));
     assertThat(toSql(root, DatabaseProduct.BIG_QUERY.getDialect()), isLinux(expectedBiqQuery));
     assertThat(toSql(root, DatabaseProduct.HIVE.getDialect()), isLinux(expectedHive));
@@ -9860,7 +9893,10 @@ class RelToSqlConverterTest {
         .build();
     final String expectedBiqQuery = "SELECT DATE_ADD(DATE '1999-07-01', INTERVAL 1 DAY) AS FD\n"
         + "FROM scott.EMP";
+    final String expectedSparkQuery = "SELECT DATE '1999-07-01' + INTERVAL '1' DAY FD\n" +
+        "FROM scott.EMP";
     assertThat(toSql(root, DatabaseProduct.BIG_QUERY.getDialect()), isLinux(expectedBiqQuery));
+    assertThat(toSql(root, DatabaseProduct.SPARK.getDialect()), isLinux(expectedSparkQuery));
   }
 
   @Test public void testPlusForDateSub() {
@@ -9877,7 +9913,10 @@ class RelToSqlConverterTest {
         .build();
     final String expectedBiqQuery = "SELECT DATE_SUB(DATE '1999-07-01', INTERVAL 1 DAY) AS FD\n"
         + "FROM scott.EMP";
+    final String expectedSparkQuery = "SELECT DATE '1999-07-01' - INTERVAL '1' DAY FD\n" +
+        "FROM scott.EMP";
     assertThat(toSql(root, DatabaseProduct.BIG_QUERY.getDialect()), isLinux(expectedBiqQuery));
+    assertThat(toSql(root, DatabaseProduct.SPARK.getDialect()), isLinux(expectedSparkQuery));
   }
 
   @Test public void testWhenTableNameAndColumnNameIsSame() {
@@ -10050,8 +10089,31 @@ class RelToSqlConverterTest {
     final String expectedBiqQuery = "SELECT PARSE_DATE('%Y%m%d', '99991231') AS date1, "
         + "PARSE_TIME('%H%M%S', '122333') AS time1\n"
         + "FROM scott.EMP";
+    final String expectedSparkQuery = "SELECT PARSE_DATE('YYYYMMDD', '99991231') date1, " +
+        "PARSE_TIME('HH24MISS', '122333') time1\n" +
+        "FROM scott.EMP";
 
     assertThat(toSql(root, DatabaseProduct.CALCITE.getDialect()), isLinux(expectedSql));
     assertThat(toSql(root, DatabaseProduct.BIG_QUERY.getDialect()), isLinux(expectedBiqQuery));
+    assertThat(toSql(root, DatabaseProduct.SPARK.getDialect()), isLinux(expectedSparkQuery));
+  }
+
+  @Test public void testPositionOperator() {
+    final RelBuilder builder = relBuilder();
+
+    final RexNode parseTrimNode = builder.call(SqlStdOperatorTable.POSITION,
+        builder.literal("a"),
+        builder.literal("Name"));
+    final RelNode root = builder.scan("EMP").
+        project(builder.alias(parseTrimNode, "t"))
+        .build();
+
+    final String expectedSql = "SELECT POSITION('a' IN 'Name') AS \"t\"\n" +
+        "FROM \"scott\".\"EMP\"";
+
+    final String expectedSparkQuery = "SELECT POSITION('a' IN 'Name') t\nFROM scott.EMP";
+
+    assertThat(toSql(root, DatabaseProduct.CALCITE.getDialect()), isLinux(expectedSql));
+    assertThat(toSql(root, DatabaseProduct.SPARK.getDialect()), isLinux(expectedSparkQuery));
   }
 }


### PR DESCRIPTION
- Support for [Position function](https://spark.apache.org/docs/latest/api/sql/index.html#position)

- Support for [Trim function](https://spark.apache.org/docs/latest/api/sql/#trim)

- Support for [Concat Pipe operator](https://docs.databricks.com/spark/latest/spark-sql/language-manual/functions/pipepipesign.html)

- Latest [Datetime patterns](https://spark.apache.org/docs/latest/sql-ref-datetime-pattern.html) 
- Reverted back addition of date +- interval DAY(before it was data_add, date_sub), date +- interval month(add_months) to binary operators as QA wants it  that way. 