### PR TITLE
Emulation of null direction in spark

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/dialect/SparkSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/SparkSqlDialect.java
@@ -121,7 +121,7 @@ public class SparkSqlDialect extends SqlDialect {
           ReturnTypes.ARG0_NULLABLE_VARYING, null, null,
           SqlFunctionCategory.STRING);
 
-  private static final Map<SqlDateTimeFormat, String> DATE_TIME_FORMAT_MAP =
+  protected static final Map<SqlDateTimeFormat, String> DATE_TIME_FORMAT_MAP =
       new HashMap<SqlDateTimeFormat, String>() {{
         put(DAYOFMONTH, "dd");
         put(DAYOFYEAR, "ddd");
@@ -161,7 +161,7 @@ public class SparkSqlDialect extends SqlDialect {
    */
   public SparkSqlDialect(SqlDialect.Context context) {
     super(context);
-    emulateNullDirection = true;
+    emulateNullDirection = false;
   }
 
   @Override protected boolean allowsAs() {

--- a/core/src/main/java/org/apache/calcite/sql/dialect/SparkSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/SparkSqlDialect.java
@@ -42,7 +42,6 @@ import org.apache.calcite.sql.SqlSyntax;
 import org.apache.calcite.sql.SqlUtil;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.fun.SqlFloorFunction;
-import org.apache.calcite.sql.fun.SqlMonotonicBinaryOperator;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.parser.CurrentTimestampHandler;
 import org.apache.calcite.sql.parser.SqlParserPos;
@@ -92,9 +91,6 @@ import static org.apache.calcite.sql.SqlDateTimeFormat.TWENTYFOURHOUR;
 import static org.apache.calcite.sql.SqlDateTimeFormat.TWODIGITYEAR;
 import static org.apache.calcite.sql.SqlDateTimeFormat.YYMMDD;
 import static org.apache.calcite.sql.SqlDateTimeFormat.YYYYMMDD;
-import static org.apache.calcite.sql.fun.SqlLibraryOperators.ADD_MONTHS;
-import static org.apache.calcite.sql.fun.SqlLibraryOperators.BINARY_DATE_ADD;
-import static org.apache.calcite.sql.fun.SqlLibraryOperators.BINARY_DATE_SUB;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.DATE_FORMAT;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.FROM_UNIXTIME;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.RAISE_ERROR;
@@ -125,7 +121,7 @@ public class SparkSqlDialect extends SqlDialect {
           ReturnTypes.ARG0_NULLABLE_VARYING, null, null,
           SqlFunctionCategory.STRING);
 
-  protected static final Map<SqlDateTimeFormat, String> DATE_TIME_FORMAT_MAP =
+  private static final Map<SqlDateTimeFormat, String> DATE_TIME_FORMAT_MAP =
       new HashMap<SqlDateTimeFormat, String>() {{
         put(DAYOFMONTH, "dd");
         put(DAYOFYEAR, "ddd");
@@ -227,15 +223,11 @@ public class SparkSqlDialect extends SqlDialect {
     case DATE:
       switch (call.getOperands().get(1).getType().getSqlTypeName()) {
       case INTERVAL_DAY:
-        if (call.op.kind == SqlKind.MINUS) {
-          return BINARY_DATE_SUB;
-        }
-        return BINARY_DATE_ADD;
       case INTERVAL_MONTH:
-        if (call.getOperator() instanceof SqlMonotonicBinaryOperator) {
-          return call.getOperator();
+        if (call.op.kind == SqlKind.MINUS) {
+          return MINUS;
         }
-        return ADD_MONTHS;
+        return PLUS;
       }
     default:
       return super.getTargetFunc(call);
@@ -416,7 +408,7 @@ public class SparkSqlDialect extends SqlDialect {
    * @return Modified SqlNode
    */
 
-  public static SqlNode modifySqlNode(SqlWriter writer, SqlNode intervalOperand) {
+  private SqlNode modifySqlNode(SqlWriter writer, SqlNode intervalOperand) {
 
     if (intervalOperand.getKind() == SqlKind.LITERAL) {
       return modifySqlNodeForLiteral(writer, intervalOperand);
@@ -438,7 +430,7 @@ public class SparkSqlDialect extends SqlDialect {
    * @param intervalOperand store_id * INTERVAL 2 DAY
    * @return Modified SqlNode store_id * 2
    */
-  private static SqlNode modifySqlNodeForExpression(SqlWriter writer, SqlNode intervalOperand) {
+  private SqlNode modifySqlNodeForExpression(SqlWriter writer, SqlNode intervalOperand) {
     SqlLiteral intervalLiteralValue = getIntervalLiteral(intervalOperand);
     SqlNode identifierValue = getIdentifier(intervalOperand);
     SqlIntervalLiteral.IntervalValue interval =
@@ -466,7 +458,7 @@ public class SparkSqlDialect extends SqlDialect {
    * @param intervalOperand INTERVAL 1 DAY
    * @return Modified SqlNode 1
    */
-  private static SqlNode modifySqlNodeForLiteral(SqlWriter writer, SqlNode intervalOperand) {
+  private SqlNode modifySqlNodeForLiteral(SqlWriter writer, SqlNode intervalOperand) {
     SqlIntervalLiteral.IntervalValue interval =
         (SqlIntervalLiteral.IntervalValue) ((SqlIntervalLiteral) intervalOperand).getValue();
     writeNegativeLiteral(interval, writer);
@@ -479,7 +471,7 @@ public class SparkSqlDialect extends SqlDialect {
    * @param intervalOperand store_id * INTERVAL 1 DAY
    * @return SqlLiteral INTERVAL 1 DAY
    */
-  public static SqlLiteral getIntervalLiteral(SqlNode intervalOperand) {
+  public SqlLiteral getIntervalLiteral(SqlNode intervalOperand) {
     if ((((SqlBasicCall) intervalOperand).operand(1).getKind() == SqlKind.IDENTIFIER)
         || (((SqlBasicCall) intervalOperand).operand(1) instanceof SqlNumericLiteral)) {
       return ((SqlBasicCall) intervalOperand).operand(0);
@@ -493,7 +485,7 @@ public class SparkSqlDialect extends SqlDialect {
    * @param intervalOperand Store_id * INTERVAL 1 DAY
    * @return SqlIdentifier Store_id
    */
-  public static SqlNode getIdentifier(SqlNode intervalOperand) {
+  public SqlNode getIdentifier(SqlNode intervalOperand) {
     if (((SqlBasicCall) intervalOperand).operand(1).getKind() == SqlKind.IDENTIFIER
         || (((SqlBasicCall) intervalOperand).operand(1) instanceof SqlNumericLiteral)) {
       return ((SqlBasicCall) intervalOperand).operand(1);
@@ -501,7 +493,7 @@ public class SparkSqlDialect extends SqlDialect {
     return ((SqlBasicCall) intervalOperand).operand(0);
   }
 
-  private static void writeNegativeLiteral(
+  private void writeNegativeLiteral(
       SqlIntervalLiteral.IntervalValue interval,
       SqlWriter writer) {
     if (interval.signum() == -1) {

--- a/core/src/main/java/org/apache/calcite/sql/dialect/SparkSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/SparkSqlDialect.java
@@ -479,7 +479,7 @@ public class SparkSqlDialect extends SqlDialect {
    * @param intervalOperand store_id * INTERVAL 1 DAY
    * @return SqlLiteral INTERVAL 1 DAY
    */
-  private static SqlLiteral getIntervalLiteral(SqlNode intervalOperand) {
+  public static SqlLiteral getIntervalLiteral(SqlNode intervalOperand) {
     if ((((SqlBasicCall) intervalOperand).operand(1).getKind() == SqlKind.IDENTIFIER)
         || (((SqlBasicCall) intervalOperand).operand(1) instanceof SqlNumericLiteral)) {
       return ((SqlBasicCall) intervalOperand).operand(0);

--- a/core/src/main/java/org/apache/calcite/sql/dialect/SparkSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/SparkSqlDialect.java
@@ -42,7 +42,6 @@ import org.apache.calcite.sql.SqlSyntax;
 import org.apache.calcite.sql.SqlUtil;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.fun.SqlFloorFunction;
-import org.apache.calcite.sql.fun.SqlLibraryOperators;
 import org.apache.calcite.sql.fun.SqlMonotonicBinaryOperator;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.parser.CurrentTimestampHandler;
@@ -93,6 +92,7 @@ import static org.apache.calcite.sql.SqlDateTimeFormat.TWENTYFOURHOUR;
 import static org.apache.calcite.sql.SqlDateTimeFormat.TWODIGITYEAR;
 import static org.apache.calcite.sql.SqlDateTimeFormat.YYMMDD;
 import static org.apache.calcite.sql.SqlDateTimeFormat.YYYYMMDD;
+import static org.apache.calcite.sql.fun.SqlLibraryOperators.ADD_MONTHS;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.BINARY_DATE_ADD;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.BINARY_DATE_SUB;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.DATE_FORMAT;
@@ -231,12 +231,12 @@ public class SparkSqlDialect extends SqlDialect {
           return BINARY_DATE_SUB;
         }
         return BINARY_DATE_ADD;
+      case INTERVAL_MONTH:
+        if (call.getOperator() instanceof SqlMonotonicBinaryOperator) {
+          return call.getOperator();
+        }
+        return ADD_MONTHS;
       }
-    case INTERVAL_MONTH:
-      if (call.getOperator() instanceof SqlMonotonicBinaryOperator) {
-        return call.getOperator();
-      }
-      return SqlLibraryOperators.ADD_MONTHS;
     default:
       return super.getTargetFunc(call);
     }

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -23,11 +23,13 @@ import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlOperatorBinding;
 import org.apache.calcite.sql.SqlOperatorTable;
 import org.apache.calcite.sql.SqlSyntax;
 import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.dialect.SparkSqlDialect;
 import org.apache.calcite.sql.type.InferTypes;
 import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.ReturnTypes;
@@ -1347,4 +1349,42 @@ public abstract class SqlLibraryOperators {
           null,
           OperandTypes.STRING,
           SqlFunctionCategory.SYSTEM);
+
+  @LibraryOperator(libraries = {SPARK})
+  public static final SqlFunction BINARY_DATE_ADD =
+      new SqlFunction(
+          "+",
+          SqlKind.OTHER_FUNCTION,
+          ReturnTypes.DATE,
+          null,
+          OperandTypes.or(DATETIME_INTERVAL, DATETIME_INTEGER),
+          SqlFunctionCategory.TIMEDATE) {
+
+
+        @Override public void unparse(SqlWriter writer, SqlCall call, int leftPrec, int rightPrec) {
+          call.operand(0).unparse(writer, leftPrec, rightPrec);
+          writer.sep(getName());
+          SqlNode intervalValue = SparkSqlDialect.modifySqlNode(writer, call.operand(1));
+          writer.print(intervalValue.toString().replace("`", ""));
+        }
+      };
+
+  @LibraryOperator(libraries = {SPARK})
+  public static final SqlFunction BINARY_DATE_SUB =
+      new SqlFunction(
+          "-",
+          SqlKind.OTHER_FUNCTION,
+          ReturnTypes.DATE,
+          null,
+          OperandTypes.or(DATETIME_INTERVAL, DATETIME_INTEGER),
+          SqlFunctionCategory.TIMEDATE) {
+
+
+        @Override public void unparse(SqlWriter writer, SqlCall call, int leftPrec, int rightPrec) {
+          call.operand(0).unparse(writer, leftPrec, rightPrec);
+          writer.sep(getName());
+          SqlNode intervalValue = SparkSqlDialect.modifySqlNode(writer, call.operand(1));
+          writer.print(intervalValue.toString().replace("`", ""));
+        }
+      };
 }

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -23,13 +23,11 @@ import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.SqlKind;
-import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlOperatorBinding;
 import org.apache.calcite.sql.SqlOperatorTable;
 import org.apache.calcite.sql.SqlSyntax;
 import org.apache.calcite.sql.SqlWriter;
-import org.apache.calcite.sql.dialect.SparkSqlDialect;
 import org.apache.calcite.sql.type.InferTypes;
 import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.ReturnTypes;
@@ -1349,42 +1347,4 @@ public abstract class SqlLibraryOperators {
           null,
           OperandTypes.STRING,
           SqlFunctionCategory.SYSTEM);
-
-  @LibraryOperator(libraries = {SPARK})
-  public static final SqlFunction BINARY_DATE_ADD =
-      new SqlFunction(
-          "+",
-          SqlKind.OTHER_FUNCTION,
-          ReturnTypes.DATE,
-          null,
-          OperandTypes.or(DATETIME_INTERVAL, DATETIME_INTEGER),
-          SqlFunctionCategory.TIMEDATE) {
-
-
-        @Override public void unparse(SqlWriter writer, SqlCall call, int leftPrec, int rightPrec) {
-          call.operand(0).unparse(writer, leftPrec, rightPrec);
-          writer.sep(getName());
-          SqlNode intervalValue = SparkSqlDialect.modifySqlNode(writer, call.operand(1));
-          writer.print(intervalValue.toString().replace("`", ""));
-        }
-      };
-
-  @LibraryOperator(libraries = {SPARK})
-  public static final SqlFunction BINARY_DATE_SUB =
-      new SqlFunction(
-          "-",
-          SqlKind.OTHER_FUNCTION,
-          ReturnTypes.DATE,
-          null,
-          OperandTypes.or(DATETIME_INTERVAL, DATETIME_INTEGER),
-          SqlFunctionCategory.TIMEDATE) {
-
-
-        @Override public void unparse(SqlWriter writer, SqlCall call, int leftPrec, int rightPrec) {
-          call.operand(0).unparse(writer, leftPrec, rightPrec);
-          writer.sep(getName());
-          SqlNode intervalValue = SparkSqlDialect.modifySqlNode(writer, call.operand(1));
-          writer.print(intervalValue.toString().replace("`", ""));
-        }
-      };
 }

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -6476,13 +6476,13 @@ class RelToSqlConverterTest {
         + "FROM \"foodmart\".\"employee\"";
     sql(query)
         .withHive()
-//        .ok(expectedHive)
-//        .withBigQuery()
-//        .ok(expectedBigQuery)
+        .ok(expectedHive)
+        .withBigQuery()
+        .ok(expectedBigQuery)
         .withSpark()
-        .ok(expectedSpark);
-//        .withSnowflake()
-//        .ok(expectedSnowflake);
+        .ok(expectedSpark)
+        .withSnowflake()
+        .ok(expectedSnowflake);
   }
 
   @Test public void testIntervalHourToSecond() {

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -111,6 +111,7 @@ import java.util.stream.IntStream;
 
 import static org.apache.calcite.avatica.util.TimeUnit.DAY;
 import static org.apache.calcite.avatica.util.TimeUnit.MICROSECOND;
+import static org.apache.calcite.avatica.util.TimeUnit.MONTH;
 import static org.apache.calcite.test.Matchers.isLinux;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -6045,7 +6046,7 @@ class RelToSqlConverterTest {
     String query = "select \"birth_date\" - INTERVAL -'1' MONTH from \"employee\"";
     final String expectedHive = "SELECT ADD_MONTHS(birth_date, -1)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT birth_date - INTERVAL '1' MONTH\nFROM foodmart.employee";
+    final String expectedSpark = "SELECT ADD_MONTHS(birth_date, -1)\nFROM foodmart.employee";
     final String expectedBigQuery = "SELECT DATE_SUB(birth_date, INTERVAL -1 MONTH)\n"
         + "FROM foodmart.employee";
     sql(query)
@@ -6061,7 +6062,7 @@ class RelToSqlConverterTest {
     String query = "select \"birth_date\" + -10 * INTERVAL '1' MONTH from \"employee\"";
     final String expectedHive = "SELECT ADD_MONTHS(birth_date, -10)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT birth_date + -10 * INTERVAL '1' MONTH\nFROM foodmart"
+    final String expectedSpark = "SELECT ADD_MONTHS(birth_date, -10)\nFROM foodmart"
         + ".employee";
     final String expectedBigQuery = "SELECT DATE_ADD(birth_date, INTERVAL -10 MONTH)\n"
         + "FROM foodmart.employee";
@@ -6089,7 +6090,7 @@ class RelToSqlConverterTest {
     String query = "select \"birth_date\" +  \"store_id\" * INTERVAL '10' MONTH from \"employee\"";
     final String expectedHive = "SELECT ADD_MONTHS(birth_date, store_id * 10)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT birth_date + store_id * INTERVAL '10' MONTH\nFROM "
+    final String expectedSpark = "SELECT ADD_MONTHS(birth_date, store_id * 10)\nFROM "
         + "foodmart.employee";
     final String expectedBigQuery = "SELECT DATE_ADD(birth_date, INTERVAL store_id * 10 MONTH)\n"
         + "FROM foodmart.employee";
@@ -6106,7 +6107,7 @@ class RelToSqlConverterTest {
     String query = "select \"birth_date\" + 10 * INTERVAL '2' MONTH from \"employee\"";
     final String expectedHive = "SELECT ADD_MONTHS(birth_date, 10 * 2)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT birth_date + 10 * INTERVAL '2' MONTH\nFROM foodmart"
+    final String expectedSpark = "SELECT ADD_MONTHS(birth_date, 10 * 2)\nFROM foodmart"
         + ".employee";
     final String expectedBigQuery = "SELECT DATE_ADD(birth_date, INTERVAL 10 * 2 MONTH)\n"
         + "FROM foodmart.employee";
@@ -6123,7 +6124,7 @@ class RelToSqlConverterTest {
     String query = "select \"birth_date\" + INTERVAL '1' DAY from \"employee\"";
     final String expectedHive = "SELECT CAST(DATE_ADD(birth_date, 1) AS DATE)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT birth_date + INTERVAL '1' DAY\nFROM foodmart.employee";
+    final String expectedSpark = "SELECT birth_date + 1\nFROM foodmart.employee";
     final String expectedBigQuery = "SELECT DATE_ADD(birth_date, INTERVAL 1 DAY)\n"
         + "FROM foodmart.employee";
     final String expectedSnowflake = "SELECT DATEADD(DAY, 1, \"birth_date\")\n"
@@ -6143,7 +6144,7 @@ class RelToSqlConverterTest {
     String query = "select \"birth_date\" - INTERVAL '1' DAY from \"employee\"";
     final String expectedHive = "SELECT CAST(DATE_SUB(birth_date, 1) AS DATE)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT birth_date - INTERVAL '1' DAY\nFROM foodmart.employee";
+    final String expectedSpark = "SELECT birth_date - 1\nFROM foodmart.employee";
     final String expectedBigQuery = "SELECT DATE_SUB(birth_date, INTERVAL 1 DAY)\n"
         + "FROM foodmart.employee";
     final String expectedSnowflake = "SELECT DATEADD(DAY, -1, \"birth_date\")\n"
@@ -6163,7 +6164,7 @@ class RelToSqlConverterTest {
     String query = "select DATE'2018-01-01' + INTERVAL '1' DAY from \"employee\"";
     final String expectedHive = "SELECT CAST(DATE_ADD(DATE '2018-01-01', 1) AS DATE)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT DATE '2018-01-01' + INTERVAL '1' DAY\nFROM foodmart"
+    final String expectedSpark = "SELECT DATE '2018-01-01' + 1\nFROM foodmart"
         + ".employee";
     final String expectedBigQuery = "SELECT DATE_ADD(DATE '2018-01-01', INTERVAL 1 DAY)\n"
         + "FROM foodmart.employee";
@@ -6184,7 +6185,7 @@ class RelToSqlConverterTest {
     String query = "select DATE'2018-01-01' - INTERVAL '1' DAY from \"employee\"";
     final String expectedHive = "SELECT CAST(DATE_SUB(DATE '2018-01-01', 1) AS DATE)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT DATE '2018-01-01' - INTERVAL '1' DAY\n"
+    final String expectedSpark = "SELECT DATE '2018-01-01' - 1\n"
         + "FROM foodmart.employee";
     final String expectedBigQuery = "SELECT DATE_SUB(DATE '2018-01-01', INTERVAL 1 DAY)\n"
         + "FROM foodmart.employee";
@@ -6205,7 +6206,7 @@ class RelToSqlConverterTest {
     String query = "select \"birth_date\" + INTERVAL '2' day from \"employee\"";
     final String expectedHive = "SELECT CAST(DATE_ADD(birth_date, 2) AS DATE)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT birth_date + INTERVAL '2' DAY\nFROM foodmart.employee";
+    final String expectedSpark = "SELECT birth_date + 2\nFROM foodmart.employee";
     final String expectedBigQuery = "SELECT DATE_ADD(birth_date, INTERVAL 2 DAY)\n"
         + "FROM foodmart.employee";
     final String expectedSnowflake = "SELECT DATEADD(DAY, 2, \"birth_date\")\n"
@@ -6257,7 +6258,7 @@ class RelToSqlConverterTest {
     String query = "select \"birth_date\" - INTERVAL '2' day from \"employee\"";
     final String expectedHive = "SELECT CAST(DATE_SUB(birth_date, 2) AS DATE)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT birth_date - INTERVAL '2' DAY"
+    final String expectedSpark = "SELECT birth_date - 2"
         + "\nFROM foodmart.employee";
     final String expectedBigQuery = "SELECT DATE_SUB(birth_date, INTERVAL 2 DAY)\n"
         + "FROM foodmart.employee";
@@ -6278,7 +6279,7 @@ class RelToSqlConverterTest {
     String query = "select \"birth_date\" + \"store_id\" * INTERVAL '1' DAY from \"employee\"";
     final String expectedHive = "SELECT CAST(DATE_ADD(birth_date, store_id) AS DATE)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT birth_date + store_id * INTERVAL '1' DAY"
+    final String expectedSpark = "SELECT birth_date + store_id"
         + "\nFROM foodmart.employee";
     final String expectedBigQuery = "SELECT DATE_ADD(birth_date, INTERVAL store_id DAY)\n"
         + "FROM foodmart.employee";
@@ -6299,7 +6300,7 @@ class RelToSqlConverterTest {
     String query = "select \"birth_date\" +  INTERVAL '1' DAY * \"store_id\" from \"employee\"";
     final String expectedHive = "SELECT CAST(DATE_ADD(birth_date, store_id) AS DATE)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT birth_date + INTERVAL '1' DAY * store_id\nFROM foodmart"
+    final String expectedSpark = "SELECT birth_date + store_id\nFROM foodmart"
         + ".employee";
     final String expectedBigQuery = "SELECT DATE_ADD(birth_date, INTERVAL store_id DAY)\n"
         + "FROM foodmart.employee";
@@ -6320,7 +6321,7 @@ class RelToSqlConverterTest {
     String query = "select \"birth_date\" +  INTERVAL '1' DAY * 10 from \"employee\"";
     final String expectedHive = "SELECT CAST(DATE_ADD(birth_date, 10) AS DATE)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT birth_date + INTERVAL '1' DAY * 10\n"
+    final String expectedSpark = "SELECT birth_date + 10\n"
         + "FROM foodmart.employee";
     final String expectedBigQuery = "SELECT DATE_ADD(birth_date, INTERVAL 10 DAY)\n"
         + "FROM foodmart.employee";
@@ -6341,7 +6342,7 @@ class RelToSqlConverterTest {
     String query = "select \"birth_date\" - \"store_id\" * INTERVAL '1' DAY from \"employee\"";
     final String expectedHive = "SELECT CAST(DATE_SUB(birth_date, store_id) AS DATE)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT birth_date - store_id * INTERVAL '1' DAY"
+    final String expectedSpark = "SELECT birth_date - store_id"
         + "\nFROM foodmart.employee";
     final String expectedBigQuery = "SELECT DATE_SUB(birth_date, INTERVAL store_id DAY)\n"
         + "FROM foodmart.employee";
@@ -6362,7 +6363,7 @@ class RelToSqlConverterTest {
     String query = "select DATE'2018-01-01' + \"store_id\" * INTERVAL '1' DAY from \"employee\"";
     final String expectedHive = "SELECT CAST(DATE_ADD(DATE '2018-01-01', store_id) AS DATE)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT DATE '2018-01-01' + store_id * INTERVAL '1' DAY\nFROM "
+    final String expectedSpark = "SELECT DATE '2018-01-01' + store_id\nFROM "
         + "foodmart.employee";
     final String expectedBigQuery = "SELECT DATE_ADD(DATE '2018-01-01', INTERVAL store_id DAY)\n"
         + "FROM foodmart.employee";
@@ -6383,7 +6384,7 @@ class RelToSqlConverterTest {
     String query = "select \"birth_date\" + \"store_id\" *11 * INTERVAL '1' DAY from \"employee\"";
     final String expectedHive = "SELECT CAST(DATE_ADD(birth_date, store_id * 11) AS DATE)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT birth_date + store_id * 11 * INTERVAL '1' DAY\nFROM "
+    final String expectedSpark = "SELECT birth_date + store_id * 11\nFROM "
         +  "foodmart.employee";
     final String expectedBigQuery = "SELECT DATE_ADD(birth_date, INTERVAL store_id * 11 DAY)\n"
         + "FROM foodmart.employee";
@@ -6404,7 +6405,7 @@ class RelToSqlConverterTest {
     String query = "select \"birth_date\" + \"store_id\"  * INTERVAL '11' DAY from \"employee\"";
     final String expectedHive = "SELECT CAST(DATE_ADD(birth_date, store_id * 11) AS DATE)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT birth_date + store_id * INTERVAL '11' DAY\nFROM "
+    final String expectedSpark = "SELECT birth_date + store_id * 11\nFROM "
         + "foodmart.employee";
     final String expectedBigQuery = "SELECT DATE_ADD(birth_date, INTERVAL store_id * 11 DAY)\n"
         + "FROM foodmart.employee";
@@ -6425,7 +6426,7 @@ class RelToSqlConverterTest {
     String query = "select \"birth_date\" - \"store_id\"  * INTERVAL '11' DAY from \"employee\"";
     final String expectedHive = "SELECT CAST(DATE_SUB(birth_date, store_id * 11) AS DATE)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT birth_date - store_id * INTERVAL '11' DAY\nFROM "
+    final String expectedSpark = "SELECT birth_date - store_id * 11\nFROM "
         + "foodmart.employee";
     final String expectedBigQuery = "SELECT DATE_SUB(birth_date, INTERVAL store_id * 11 DAY)\n"
         + "FROM foodmart.employee";
@@ -6446,7 +6447,7 @@ class RelToSqlConverterTest {
     String query = "select \"birth_date\" + 10 * INTERVAL '2' DAY from \"employee\"";
     final String expectedHive = "SELECT CAST(DATE_ADD(birth_date, 10 * 2) AS DATE)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT birth_date + 10 * INTERVAL '2' DAY\n"
+    final String expectedSpark = "SELECT birth_date + 10 * 2\n"
         + "FROM foodmart.employee";
     final String expectedBigQuery = "SELECT DATE_ADD(birth_date, INTERVAL 10 * 2 DAY)\n"
         + "FROM foodmart.employee";
@@ -6467,7 +6468,7 @@ class RelToSqlConverterTest {
     String query = "select  INTERVAL '1' DAY + \"birth_date\" from \"employee\"";
     final String expectedHive = "SELECT CAST(DATE_ADD(birth_date, 1) AS DATE)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT birth_date + INTERVAL '1' DAY\n"
+    final String expectedSpark = "SELECT birth_date + 1\n"
         + "FROM foodmart.employee";
     final String expectedBigQuery = "SELECT DATE_ADD(birth_date, INTERVAL 1 DAY)\n"
         + "FROM foodmart.employee";
@@ -6475,13 +6476,13 @@ class RelToSqlConverterTest {
         + "FROM \"foodmart\".\"employee\"";
     sql(query)
         .withHive()
-        .ok(expectedHive)
-        .withBigQuery()
-        .ok(expectedBigQuery)
+//        .ok(expectedHive)
+//        .withBigQuery()
+//        .ok(expectedBigQuery)
         .withSpark()
-        .ok(expectedSpark)
-        .withSnowflake()
-        .ok(expectedSnowflake);
+        .ok(expectedSpark);
+//        .withSnowflake()
+//        .ok(expectedSnowflake);
   }
 
   @Test public void testIntervalHourToSecond() {
@@ -9913,7 +9914,7 @@ class RelToSqlConverterTest {
         .build();
     final String expectedBiqQuery = "SELECT DATE_ADD(DATE '1999-07-01', INTERVAL 1 DAY) AS FD\n"
         + "FROM scott.EMP";
-    final String expectedSparkQuery = "SELECT DATE '1999-07-01' + INTERVAL '1' DAY FD\n"
+    final String expectedSparkQuery = "SELECT DATE '1999-07-01' + 1 FD\n"
         + "FROM scott.EMP";
     assertThat(toSql(root, DatabaseProduct.BIG_QUERY.getDialect()), isLinux(expectedBiqQuery));
     assertThat(toSql(root, DatabaseProduct.SPARK.getDialect()), isLinux(expectedSparkQuery));
@@ -9933,7 +9934,7 @@ class RelToSqlConverterTest {
         .build();
     final String expectedBiqQuery = "SELECT DATE_SUB(DATE '1999-07-01', INTERVAL 1 DAY) AS FD\n"
         + "FROM scott.EMP";
-    final String expectedSparkQuery = "SELECT DATE '1999-07-01' - INTERVAL '1' DAY FD\n"
+    final String expectedSparkQuery = "SELECT DATE '1999-07-01' - 1 FD\n"
         + "FROM scott.EMP";
     assertThat(toSql(root, DatabaseProduct.BIG_QUERY.getDialect()), isLinux(expectedBiqQuery));
     assertThat(toSql(root, DatabaseProduct.SPARK.getDialect()), isLinux(expectedSparkQuery));
@@ -10161,6 +10162,23 @@ class RelToSqlConverterTest {
         + "FROM scott.EMP";
 
     assertThat(toSql(root, DatabaseProduct.CALCITE.getDialect()), isLinux(expectedSql));
+    assertThat(toSql(root, DatabaseProduct.SPARK.getDialect()), isLinux(expectedSparkQuery));
+  }
+
+  @Test public void testForAddingMonths() {
+    final RelBuilder builder = relBuilder();
+
+    final RexNode createRexNode = builder.call(SqlStdOperatorTable.PLUS,
+        builder.cast(builder.literal("1999-07-01"), SqlTypeName.DATE),
+        builder.getRexBuilder().makeIntervalLiteral(new BigDecimal(10),
+            new SqlIntervalQualifier(MONTH, 6, MONTH,
+                -1, SqlParserPos.ZERO)));
+    final RelNode root = builder
+        .scan("EMP")
+        .project(builder.alias(createRexNode, "FD"))
+        .build();
+    final String expectedSparkQuery = "SELECT DATE '1999-07-01' + INTERVAL '10' MONTH FD"
+        + "\nFROM scott.EMP";
     assertThat(toSql(root, DatabaseProduct.SPARK.getDialect()), isLinux(expectedSparkQuery));
   }
 }

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -111,7 +111,6 @@ import java.util.stream.IntStream;
 
 import static org.apache.calcite.avatica.util.TimeUnit.DAY;
 import static org.apache.calcite.avatica.util.TimeUnit.MICROSECOND;
-import static org.apache.calcite.avatica.util.TimeUnit.MONTH;
 import static org.apache.calcite.test.Matchers.isLinux;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -6046,7 +6045,7 @@ class RelToSqlConverterTest {
     String query = "select \"birth_date\" - INTERVAL -'1' MONTH from \"employee\"";
     final String expectedHive = "SELECT ADD_MONTHS(birth_date, -1)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT ADD_MONTHS(birth_date, -1)\nFROM foodmart.employee";
+    final String expectedSpark = "SELECT birth_date - INTERVAL '1' MONTH\nFROM foodmart.employee";
     final String expectedBigQuery = "SELECT DATE_SUB(birth_date, INTERVAL -1 MONTH)\n"
         + "FROM foodmart.employee";
     sql(query)
@@ -6062,7 +6061,7 @@ class RelToSqlConverterTest {
     String query = "select \"birth_date\" + -10 * INTERVAL '1' MONTH from \"employee\"";
     final String expectedHive = "SELECT ADD_MONTHS(birth_date, -10)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT ADD_MONTHS(birth_date, -10)\nFROM foodmart"
+    final String expectedSpark = "SELECT birth_date + -10 * INTERVAL '1' MONTH\nFROM foodmart"
         + ".employee";
     final String expectedBigQuery = "SELECT DATE_ADD(birth_date, INTERVAL -10 MONTH)\n"
         + "FROM foodmart.employee";
@@ -6090,7 +6089,7 @@ class RelToSqlConverterTest {
     String query = "select \"birth_date\" +  \"store_id\" * INTERVAL '10' MONTH from \"employee\"";
     final String expectedHive = "SELECT ADD_MONTHS(birth_date, store_id * 10)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT ADD_MONTHS(birth_date, store_id * 10)\nFROM "
+    final String expectedSpark = "SELECT birth_date + store_id * INTERVAL '10' MONTH\nFROM "
         + "foodmart.employee";
     final String expectedBigQuery = "SELECT DATE_ADD(birth_date, INTERVAL store_id * 10 MONTH)\n"
         + "FROM foodmart.employee";
@@ -6107,7 +6106,7 @@ class RelToSqlConverterTest {
     String query = "select \"birth_date\" + 10 * INTERVAL '2' MONTH from \"employee\"";
     final String expectedHive = "SELECT ADD_MONTHS(birth_date, 10 * 2)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT ADD_MONTHS(birth_date, 10 * 2)\nFROM foodmart"
+    final String expectedSpark = "SELECT birth_date + 10 * INTERVAL '2' MONTH\nFROM foodmart"
         + ".employee";
     final String expectedBigQuery = "SELECT DATE_ADD(birth_date, INTERVAL 10 * 2 MONTH)\n"
         + "FROM foodmart.employee";
@@ -6124,7 +6123,7 @@ class RelToSqlConverterTest {
     String query = "select \"birth_date\" + INTERVAL '1' DAY from \"employee\"";
     final String expectedHive = "SELECT CAST(DATE_ADD(birth_date, 1) AS DATE)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT birth_date + 1\nFROM foodmart.employee";
+    final String expectedSpark = "SELECT birth_date + INTERVAL '1' DAY\nFROM foodmart.employee";
     final String expectedBigQuery = "SELECT DATE_ADD(birth_date, INTERVAL 1 DAY)\n"
         + "FROM foodmart.employee";
     final String expectedSnowflake = "SELECT DATEADD(DAY, 1, \"birth_date\")\n"
@@ -6144,7 +6143,7 @@ class RelToSqlConverterTest {
     String query = "select \"birth_date\" - INTERVAL '1' DAY from \"employee\"";
     final String expectedHive = "SELECT CAST(DATE_SUB(birth_date, 1) AS DATE)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT birth_date - 1\nFROM foodmart.employee";
+    final String expectedSpark = "SELECT birth_date - INTERVAL '1' DAY\nFROM foodmart.employee";
     final String expectedBigQuery = "SELECT DATE_SUB(birth_date, INTERVAL 1 DAY)\n"
         + "FROM foodmart.employee";
     final String expectedSnowflake = "SELECT DATEADD(DAY, -1, \"birth_date\")\n"
@@ -6164,7 +6163,7 @@ class RelToSqlConverterTest {
     String query = "select DATE'2018-01-01' + INTERVAL '1' DAY from \"employee\"";
     final String expectedHive = "SELECT CAST(DATE_ADD(DATE '2018-01-01', 1) AS DATE)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT DATE '2018-01-01' + 1\nFROM foodmart"
+    final String expectedSpark = "SELECT DATE '2018-01-01' + INTERVAL '1' DAY\nFROM foodmart"
         + ".employee";
     final String expectedBigQuery = "SELECT DATE_ADD(DATE '2018-01-01', INTERVAL 1 DAY)\n"
         + "FROM foodmart.employee";
@@ -6185,7 +6184,7 @@ class RelToSqlConverterTest {
     String query = "select DATE'2018-01-01' - INTERVAL '1' DAY from \"employee\"";
     final String expectedHive = "SELECT CAST(DATE_SUB(DATE '2018-01-01', 1) AS DATE)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT DATE '2018-01-01' - 1\n"
+    final String expectedSpark = "SELECT DATE '2018-01-01' - INTERVAL '1' DAY\n"
         + "FROM foodmart.employee";
     final String expectedBigQuery = "SELECT DATE_SUB(DATE '2018-01-01', INTERVAL 1 DAY)\n"
         + "FROM foodmart.employee";
@@ -6206,7 +6205,7 @@ class RelToSqlConverterTest {
     String query = "select \"birth_date\" + INTERVAL '2' day from \"employee\"";
     final String expectedHive = "SELECT CAST(DATE_ADD(birth_date, 2) AS DATE)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT birth_date + 2\nFROM foodmart.employee";
+    final String expectedSpark = "SELECT birth_date + INTERVAL '2' DAY\nFROM foodmart.employee";
     final String expectedBigQuery = "SELECT DATE_ADD(birth_date, INTERVAL 2 DAY)\n"
         + "FROM foodmart.employee";
     final String expectedSnowflake = "SELECT DATEADD(DAY, 2, \"birth_date\")\n"
@@ -6258,7 +6257,7 @@ class RelToSqlConverterTest {
     String query = "select \"birth_date\" - INTERVAL '2' day from \"employee\"";
     final String expectedHive = "SELECT CAST(DATE_SUB(birth_date, 2) AS DATE)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT birth_date - 2"
+    final String expectedSpark = "SELECT birth_date - INTERVAL '2' DAY"
         + "\nFROM foodmart.employee";
     final String expectedBigQuery = "SELECT DATE_SUB(birth_date, INTERVAL 2 DAY)\n"
         + "FROM foodmart.employee";
@@ -6279,7 +6278,7 @@ class RelToSqlConverterTest {
     String query = "select \"birth_date\" + \"store_id\" * INTERVAL '1' DAY from \"employee\"";
     final String expectedHive = "SELECT CAST(DATE_ADD(birth_date, store_id) AS DATE)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT birth_date + store_id"
+    final String expectedSpark = "SELECT birth_date + store_id * INTERVAL '1' DAY"
         + "\nFROM foodmart.employee";
     final String expectedBigQuery = "SELECT DATE_ADD(birth_date, INTERVAL store_id DAY)\n"
         + "FROM foodmart.employee";
@@ -6300,7 +6299,7 @@ class RelToSqlConverterTest {
     String query = "select \"birth_date\" +  INTERVAL '1' DAY * \"store_id\" from \"employee\"";
     final String expectedHive = "SELECT CAST(DATE_ADD(birth_date, store_id) AS DATE)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT birth_date + store_id\nFROM foodmart"
+    final String expectedSpark = "SELECT birth_date + INTERVAL '1' DAY * store_id\nFROM foodmart"
         + ".employee";
     final String expectedBigQuery = "SELECT DATE_ADD(birth_date, INTERVAL store_id DAY)\n"
         + "FROM foodmart.employee";
@@ -6321,7 +6320,7 @@ class RelToSqlConverterTest {
     String query = "select \"birth_date\" +  INTERVAL '1' DAY * 10 from \"employee\"";
     final String expectedHive = "SELECT CAST(DATE_ADD(birth_date, 10) AS DATE)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT birth_date + 10\n"
+    final String expectedSpark = "SELECT birth_date + INTERVAL '1' DAY * 10\n"
         + "FROM foodmart.employee";
     final String expectedBigQuery = "SELECT DATE_ADD(birth_date, INTERVAL 10 DAY)\n"
         + "FROM foodmart.employee";
@@ -6342,7 +6341,7 @@ class RelToSqlConverterTest {
     String query = "select \"birth_date\" - \"store_id\" * INTERVAL '1' DAY from \"employee\"";
     final String expectedHive = "SELECT CAST(DATE_SUB(birth_date, store_id) AS DATE)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT birth_date - store_id"
+    final String expectedSpark = "SELECT birth_date - store_id * INTERVAL '1' DAY"
         + "\nFROM foodmart.employee";
     final String expectedBigQuery = "SELECT DATE_SUB(birth_date, INTERVAL store_id DAY)\n"
         + "FROM foodmart.employee";
@@ -6363,7 +6362,7 @@ class RelToSqlConverterTest {
     String query = "select DATE'2018-01-01' + \"store_id\" * INTERVAL '1' DAY from \"employee\"";
     final String expectedHive = "SELECT CAST(DATE_ADD(DATE '2018-01-01', store_id) AS DATE)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT DATE '2018-01-01' + store_id\nFROM "
+    final String expectedSpark = "SELECT DATE '2018-01-01' + store_id * INTERVAL '1' DAY\nFROM "
         + "foodmart.employee";
     final String expectedBigQuery = "SELECT DATE_ADD(DATE '2018-01-01', INTERVAL store_id DAY)\n"
         + "FROM foodmart.employee";
@@ -6384,7 +6383,7 @@ class RelToSqlConverterTest {
     String query = "select \"birth_date\" + \"store_id\" *11 * INTERVAL '1' DAY from \"employee\"";
     final String expectedHive = "SELECT CAST(DATE_ADD(birth_date, store_id * 11) AS DATE)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT birth_date + store_id * 11\nFROM "
+    final String expectedSpark = "SELECT birth_date + store_id * 11 * INTERVAL '1' DAY\nFROM "
         +  "foodmart.employee";
     final String expectedBigQuery = "SELECT DATE_ADD(birth_date, INTERVAL store_id * 11 DAY)\n"
         + "FROM foodmart.employee";
@@ -6405,7 +6404,7 @@ class RelToSqlConverterTest {
     String query = "select \"birth_date\" + \"store_id\"  * INTERVAL '11' DAY from \"employee\"";
     final String expectedHive = "SELECT CAST(DATE_ADD(birth_date, store_id * 11) AS DATE)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT birth_date + store_id * 11\nFROM "
+    final String expectedSpark = "SELECT birth_date + store_id * INTERVAL '11' DAY\nFROM "
         + "foodmart.employee";
     final String expectedBigQuery = "SELECT DATE_ADD(birth_date, INTERVAL store_id * 11 DAY)\n"
         + "FROM foodmart.employee";
@@ -6426,7 +6425,7 @@ class RelToSqlConverterTest {
     String query = "select \"birth_date\" - \"store_id\"  * INTERVAL '11' DAY from \"employee\"";
     final String expectedHive = "SELECT CAST(DATE_SUB(birth_date, store_id * 11) AS DATE)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT birth_date - store_id * 11\nFROM "
+    final String expectedSpark = "SELECT birth_date - store_id * INTERVAL '11' DAY\nFROM "
         + "foodmart.employee";
     final String expectedBigQuery = "SELECT DATE_SUB(birth_date, INTERVAL store_id * 11 DAY)\n"
         + "FROM foodmart.employee";
@@ -6447,7 +6446,7 @@ class RelToSqlConverterTest {
     String query = "select \"birth_date\" + 10 * INTERVAL '2' DAY from \"employee\"";
     final String expectedHive = "SELECT CAST(DATE_ADD(birth_date, 10 * 2) AS DATE)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT birth_date + 10 * 2\n"
+    final String expectedSpark = "SELECT birth_date + 10 * INTERVAL '2' DAY\n"
         + "FROM foodmart.employee";
     final String expectedBigQuery = "SELECT DATE_ADD(birth_date, INTERVAL 10 * 2 DAY)\n"
         + "FROM foodmart.employee";
@@ -6468,7 +6467,7 @@ class RelToSqlConverterTest {
     String query = "select  INTERVAL '1' DAY + \"birth_date\" from \"employee\"";
     final String expectedHive = "SELECT CAST(DATE_ADD(birth_date, 1) AS DATE)\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT birth_date + 1\n"
+    final String expectedSpark = "SELECT birth_date + INTERVAL '1' DAY\n"
         + "FROM foodmart.employee";
     final String expectedBigQuery = "SELECT DATE_ADD(birth_date, INTERVAL 1 DAY)\n"
         + "FROM foodmart.employee";
@@ -9914,7 +9913,7 @@ class RelToSqlConverterTest {
         .build();
     final String expectedBiqQuery = "SELECT DATE_ADD(DATE '1999-07-01', INTERVAL 1 DAY) AS FD\n"
         + "FROM scott.EMP";
-    final String expectedSparkQuery = "SELECT DATE '1999-07-01' + 1 FD\n"
+    final String expectedSparkQuery = "SELECT DATE '1999-07-01' + INTERVAL '1' DAY FD\n"
         + "FROM scott.EMP";
     assertThat(toSql(root, DatabaseProduct.BIG_QUERY.getDialect()), isLinux(expectedBiqQuery));
     assertThat(toSql(root, DatabaseProduct.SPARK.getDialect()), isLinux(expectedSparkQuery));
@@ -9934,7 +9933,7 @@ class RelToSqlConverterTest {
         .build();
     final String expectedBiqQuery = "SELECT DATE_SUB(DATE '1999-07-01', INTERVAL 1 DAY) AS FD\n"
         + "FROM scott.EMP";
-    final String expectedSparkQuery = "SELECT DATE '1999-07-01' - 1 FD\n"
+    final String expectedSparkQuery = "SELECT DATE '1999-07-01' - INTERVAL '1' DAY FD\n"
         + "FROM scott.EMP";
     assertThat(toSql(root, DatabaseProduct.BIG_QUERY.getDialect()), isLinux(expectedBiqQuery));
     assertThat(toSql(root, DatabaseProduct.SPARK.getDialect()), isLinux(expectedSparkQuery));
@@ -10162,23 +10161,6 @@ class RelToSqlConverterTest {
         + "FROM scott.EMP";
 
     assertThat(toSql(root, DatabaseProduct.CALCITE.getDialect()), isLinux(expectedSql));
-    assertThat(toSql(root, DatabaseProduct.SPARK.getDialect()), isLinux(expectedSparkQuery));
-  }
-
-  @Test public void testForAddingMonths() {
-    final RelBuilder builder = relBuilder();
-
-    final RexNode createRexNode = builder.call(SqlStdOperatorTable.PLUS,
-        builder.cast(builder.literal("1999-07-01"), SqlTypeName.DATE),
-        builder.getRexBuilder().makeIntervalLiteral(new BigDecimal(10),
-            new SqlIntervalQualifier(MONTH, 6, MONTH,
-                -1, SqlParserPos.ZERO)));
-    final RelNode root = builder
-        .scan("EMP")
-        .project(builder.alias(createRexNode, "FD"))
-        .build();
-    final String expectedSparkQuery = "SELECT DATE '1999-07-01' + INTERVAL '10' MONTH FD"
-        + "\nFROM scott.EMP";
     assertThat(toSql(root, DatabaseProduct.SPARK.getDialect()), isLinux(expectedSparkQuery));
   }
 }

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -1123,7 +1123,7 @@ class RelToSqlConverterTest {
         + "FROM (SELECT RANK() OVER (ORDER BY hire_date NULLS LAST) rnk\n"
         + "FROM foodmart.employee) t";
     final String expectedSpark = "SELECT MAX(rnk) rnk1\n"
-        + "FROM (SELECT RANK() OVER (ORDER BY hire_date IS NULL, hire_date) rnk\n"
+        + "FROM (SELECT RANK() OVER (ORDER BY hire_date NULLS LAST) rnk\n"
         + "FROM foodmart.employee) t";
     final String expectedBigQuery = "SELECT MAX(rnk) AS rnk1\n"
         + "FROM (SELECT RANK() OVER (ORDER BY hire_date IS NULL, hire_date) AS rnk\n"
@@ -1156,7 +1156,7 @@ class RelToSqlConverterTest {
         + " THEN 100 ELSE 200 END rnk\n"
         + "FROM foodmart.employee) t";
     final String expectedSpark = "SELECT MAX(rnk) rnk1\n"
-        + "FROM (SELECT CASE WHEN (RANK() OVER (ORDER BY hire_date IS NULL, hire_date)) = 1 "
+        + "FROM (SELECT CASE WHEN (RANK() OVER (ORDER BY hire_date NULLS LAST)) = 1 "
         + "THEN 100 ELSE 200 END rnk\n"
         + "FROM foodmart.employee) t";
     final String expectedBigQuery = "SELECT MAX(rnk) AS rnk1\n"
@@ -2359,12 +2359,15 @@ class RelToSqlConverterTest {
     final String expected = "SELECT product_id\n"
         + "FROM foodmart.product\n"
         + "ORDER BY product_id IS NULL DESC, product_id DESC";
+    final String expectedSpark = "SELECT product_id\n"
+        + "FROM foodmart.product\n"
+        + "ORDER BY product_id DESC NULLS FIRST";
     final String expectedMssql = "SELECT [product_id]\n"
         + "FROM [foodmart].[product]\n"
         + "ORDER BY CASE WHEN [product_id] IS NULL THEN 0 ELSE 1 END, [product_id] DESC";
     sql(query)
         .withSpark()
-        .ok(expected)
+        .ok(expectedSpark)
         .withHive()
         .ok(expected)
         .withBigQuery()
@@ -2410,12 +2413,14 @@ class RelToSqlConverterTest {
     final String expected = "SELECT product_id\n"
         + "FROM foodmart.product\n"
         + "ORDER BY product_id IS NULL, product_id";
+    final String expectedSpark = "SELECT product_id\nFROM foodmart.product\n"
+        + "ORDER BY product_id NULLS LAST";
     final String expectedMssql = "SELECT [product_id]\n"
         + "FROM [foodmart].[product]\n"
         + "ORDER BY CASE WHEN [product_id] IS NULL THEN 1 ELSE 0 END, [product_id]";
     sql(query)
         .withSpark()
-        .ok(expected)
+        .ok(expectedSpark)
         .withHive()
         .ok(expected)
         .withBigQuery()
@@ -7077,6 +7082,13 @@ class RelToSqlConverterTest {
         + "FROM (SELECT first_name, department_id, COUNT(*) department_id_number\n"
         + "FROM foodmart.employee\n"
         + "GROUP BY first_name, department_id) t0";
+    final String expectedSpark = "SELECT first_name, department_id_number, ROW_NUMBER() "
+        + "OVER (ORDER BY department_id NULLS LAST), SUM(department_id) "
+        + "OVER (ORDER BY department_id NULLS LAST "
+        + "RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)\n"
+        + "FROM (SELECT first_name, department_id, COUNT(*) department_id_number\n"
+        + "FROM foodmart.employee\n"
+        + "GROUP BY first_name, department_id) t0";
     final String expectedBQ = "SELECT first_name, department_id_number, "
         + "ROW_NUMBER() OVER (ORDER BY department_id IS NULL, department_id), SUM(department_id) "
         + "OVER (ORDER BY department_id IS NULL, department_id "
@@ -7101,7 +7113,7 @@ class RelToSqlConverterTest {
       .withHive()
       .ok(expected)
       .withSpark()
-      .ok(expected)
+      .ok(expectedSpark)
       .withBigQuery()
       .ok(expectedBQ)
       .withSnowflake()


### PR DESCRIPTION
Removing emulation of null direction in spark.
Support for [null direction](https://docs.databricks.com/spark/latest/spark-sql/language-manual/sql-ref-syntax-qry-select-sortby.html) in spark.
