### PR TITLE
RNBS-264-adds-subquery-support-for-In-Clause-having-functioncall-in-groupBy

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
@@ -2161,7 +2161,7 @@ public abstract class SqlImplementor {
           && clauses.contains(Clause.HAVING)
           && !hasAliasUsedInHavingClause()
           && hasAliasUsedInGroupByWhichIsNotPresentInFinalProjection((Project) rel)) {
-        stripHavingClauseFromProjection();
+        stripHavingClauseIfAggregateFromProjection();
         return true;
       }
 
@@ -2196,10 +2196,12 @@ public abstract class SqlImplementor {
       return false;
     }
 
-    private void stripHavingClauseFromProjection() {
+    private void stripHavingClauseIfAggregateFromProjection() {
       final SqlNodeList selectList = ((SqlSelect) node).getSelectList();
       final SqlNode havingSelectList = ((SqlBasicCall) ((SqlSelect) node).getHaving()).operands[0];
-      if (selectList != null && havingSelectList != null) {
+      if (selectList != null && havingSelectList != null
+          && havingSelectList instanceof SqlCall
+          && ((SqlCall) havingSelectList).getOperator().isAggregator()) {
         selectList.remove(havingSelectList);
         ((SqlSelect) node).setSelectList(selectList);
       }

--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
@@ -2140,6 +2140,14 @@ public abstract class SqlImplementor {
         }
       }
 
+      if (rel instanceof Project
+          && clauses.contains(Clause.HAVING)
+          && !hasAliasUsedInHavingClause()
+          && hasAliasUsedInGroupByWhichIsNotPresentInFinalProjection((Project) rel)) {
+        stripHavingClauseFromProjection();
+        return true;
+      }
+
       return false;
     }
 
@@ -2184,6 +2192,14 @@ public abstract class SqlImplementor {
       return false;
     }
 
+    private void stripHavingClauseFromProjection() {
+      final SqlNodeList selectList = ((SqlSelect) node).getSelectList();
+      final SqlNode havingSelectList = ((SqlBasicCall) ((SqlSelect) node).getHaving()).operands[0];
+      if (selectList != null && havingSelectList != null) {
+        selectList.remove(havingSelectList);
+        ((SqlSelect) node).setSelectList(selectList);
+      }
+    }
     boolean hasAliasUsedInGroupByWhichIsNotPresentInFinalProjection(Project rel) {
       final SqlNodeList selectList = ((SqlSelect) node).getSelectList();
       final SqlNodeList grpList = ((SqlSelect) node).getGroup();

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -10215,19 +10215,19 @@ class RelToSqlConverterTest {
         .filter(RexSubQuery.in(subQueryInClause, ImmutableList.of(builder.field(0))))
         .project(builder.field(0)).build();
 
-    final String expectedSql = "SELECT \"EMPNO\"n"
-        + "FROM \"scott\".\"EMP\"n"
-        + "WHERE \"EMPNO\" IN (SELECT 'A2301' AS \"$f0\"n"
-        + "FROM \"scott\".\"EMP\"n"
-        + "GROUP BY CHAR_LENGTH(\"ENAME\")n"
+    final String expectedSql = "SELECT \"EMPNO\"\n"
+        + "FROM \"scott\".\"EMP\"\n"
+        + "WHERE \"EMPNO\" IN (SELECT 'A2301' AS \"$f0\"\n"
+        + "FROM \"scott\".\"EMP\"\n"
+        + "GROUP BY CHAR_LENGTH(\"ENAME\")\n"
         + "HAVING CHARACTER_LENGTH('TEST') = 2)";
 
-    final String expectedBiqQuery = "SELECT EMPNOn"
-        + "FROM scott.EMPn"
-        + "WHERE EMPNO IN (SELECT 'A2301' AS `$f0`n"
-        + "FROM (SELECT LENGTH(ENAME) AS A2301n"
-        + "FROM scott.EMPn"
-        + "GROUP BY A2301n"
+    final String expectedBiqQuery = "SELECT EMPNO\n"
+        + "FROM scott.EMP\n"
+        + "WHERE EMPNO IN (SELECT 'A2301' AS `$f0`\n"
+        + "FROM (SELECT LENGTH(ENAME) AS A2301\n"
+        + "FROM scott.EMP\n"
+        + "GROUP BY A2301\n"
         + "HAVING LENGTH('TEST') = 2) AS t1)";
 
     assertThat(toSql(root, DatabaseProduct.CALCITE.getDialect()), isLinux(expectedSql));

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -10234,4 +10234,43 @@ class RelToSqlConverterTest {
     assertThat(toSql(root, DatabaseProduct.BIG_QUERY.getDialect()), isLinux(expectedBiqQuery));
   }
 
+  @Test public void testSubQueryWithFunctionCallInGroupByAndAggregateInHavingClause() {
+    final RelBuilder builder = relBuilder();
+    builder.scan("EMP");
+    final RexNode lengthFunctionCall = builder.call(SqlStdOperatorTable.CHAR_LENGTH,
+        builder.field(1));
+    final RelNode subQueryInClause = builder
+        .project(builder.alias(lengthFunctionCall, "A2301"), builder.field("EMPNO"))
+        .aggregate(builder.groupKey(builder.field(0)),
+            builder.countStar("EXPR$1354574361"))
+        .filter(
+            builder.call(SqlStdOperatorTable.EQUALS,
+                builder.field("EXPR$1354574361"), builder.literal(2)))
+        .project(Arrays.asList(builder.field(0)), Arrays.asList("a2301"), true)
+        .build();
+
+    builder.scan("EMP");
+    final RelNode root = builder
+        .filter(RexSubQuery.in(subQueryInClause, ImmutableList.of(builder.field(0))))
+        .project(builder.field(0)).build();
+
+    final String expectedSql = "SELECT \"EMPNO\"\n"
+        + "FROM \"scott\".\"EMP\"\n"
+        + "WHERE \"EMPNO\" IN (SELECT CHAR_LENGTH(\"ENAME\") AS \"a2301\"\n"
+        + "FROM \"scott\".\"EMP\"\n"
+        + "GROUP BY CHAR_LENGTH(\"ENAME\")\n"
+        + "HAVING COUNT(*) = 2)";
+
+    final String expectedBiqQuery = "SELECT EMPNO\n"
+        + "FROM scott.EMP\n"
+        + "WHERE EMPNO IN (SELECT A2301 AS a2301\n"
+        + "FROM (SELECT LENGTH(ENAME) AS A2301\n"
+        + "FROM scott.EMP\n"
+        + "GROUP BY A2301\n"
+        + "HAVING COUNT(*) = 2) AS t1)";
+
+    assertThat(toSql(root, DatabaseProduct.CALCITE.getDialect()), isLinux(expectedSql));
+    assertThat(toSql(root, DatabaseProduct.BIG_QUERY.getDialect()), isLinux(expectedBiqQuery));
+  }
+
 }

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -10215,20 +10215,20 @@ class RelToSqlConverterTest {
         .filter(RexSubQuery.in(subQueryInClause, ImmutableList.of(builder.field(0))))
         .project(builder.field(0)).build();
 
-    final String expectedSql = "SELECT \"EMPNO\"\n" +
-        "FROM \"scott\".\"EMP\"\n" +
-        "WHERE \"EMPNO\" IN (SELECT 'A2301' AS \"$f0\"\n" +
-        "FROM \"scott\".\"EMP\"\n" +
-        "GROUP BY CHAR_LENGTH(\"ENAME\")\n" +
-        "HAVING CHARACTER_LENGTH('TEST') = 2)";
+    final String expectedSql = "SELECT \"EMPNO\"n"
+        + "FROM \"scott\".\"EMP\"n"
+        + "WHERE \"EMPNO\" IN (SELECT 'A2301' AS \"$f0\"n"
+        + "FROM \"scott\".\"EMP\"n"
+        + "GROUP BY CHAR_LENGTH(\"ENAME\")n"
+        + "HAVING CHARACTER_LENGTH('TEST') = 2)";
 
-    final String expectedBiqQuery = "SELECT EMPNO\n" +
-        "FROM scott.EMP\n" +
-        "WHERE EMPNO IN (SELECT 'A2301' AS `$f0`\n" +
-        "FROM (SELECT LENGTH(ENAME) AS A2301\n" +
-        "FROM scott.EMP\n" +
-        "GROUP BY A2301\n" +
-        "HAVING LENGTH('TEST') = 2) AS t1)";
+    final String expectedBiqQuery = "SELECT EMPNOn"
+        + "FROM scott.EMPn"
+        + "WHERE EMPNO IN (SELECT 'A2301' AS `$f0`n"
+        + "FROM (SELECT LENGTH(ENAME) AS A2301n"
+        + "FROM scott.EMPn"
+        + "GROUP BY A2301n"
+        + "HAVING LENGTH('TEST') = 2) AS t1)";
 
     assertThat(toSql(root, DatabaseProduct.CALCITE.getDialect()), isLinux(expectedSql));
     assertThat(toSql(root, DatabaseProduct.BIG_QUERY.getDialect()), isLinux(expectedBiqQuery));

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -10228,7 +10228,7 @@ class RelToSqlConverterTest {
         + "FROM (SELECT LENGTH(ENAME) AS A2301\n"
         + "FROM scott.EMP\n"
         + "GROUP BY A2301\n"
-        + "HAVING LENGTH('TEST') = 2) AS t1";
+        + "HAVING LENGTH('TEST') = 2) AS t1)";
 
     assertThat(toSql(root, DatabaseProduct.CALCITE.getDialect()), isLinux(expectedSql));
     assertThat(toSql(root, DatabaseProduct.BIG_QUERY.getDialect()), isLinux(expectedBiqQuery));

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -10207,7 +10207,7 @@ class RelToSqlConverterTest {
             builder.call(SqlStdOperatorTable.EQUALS,
             builder.call(SqlStdOperatorTable.CHARACTER_LENGTH,
                 builder.literal("TEST")), builder.literal(2)))
-        .project(builder.literal("A2301"))
+        .project(Arrays.asList(builder.field(0)), Arrays.asList("a2301"), true)
         .build();
 
     builder.scan("EMP");
@@ -10217,18 +10217,18 @@ class RelToSqlConverterTest {
 
     final String expectedSql = "SELECT \"EMPNO\"\n"
         + "FROM \"scott\".\"EMP\"\n"
-        + "WHERE \"EMPNO\" IN (SELECT 'A2301' AS \"$f0\"\n"
+        + "WHERE \"EMPNO\" IN (SELECT CHAR_LENGTH(\"ENAME\") AS \"a2301\"\n"
         + "FROM \"scott\".\"EMP\"\n"
         + "GROUP BY CHAR_LENGTH(\"ENAME\")\n"
         + "HAVING CHARACTER_LENGTH('TEST') = 2)";
 
     final String expectedBiqQuery = "SELECT EMPNO\n"
         + "FROM scott.EMP\n"
-        + "WHERE EMPNO IN (SELECT 'A2301' AS `$f0`\n"
+        + "WHERE EMPNO IN (SELECT A2301 AS a2301\n"
         + "FROM (SELECT LENGTH(ENAME) AS A2301\n"
         + "FROM scott.EMP\n"
         + "GROUP BY A2301\n"
-        + "HAVING LENGTH('TEST') = 2) AS t1)";
+        + "HAVING LENGTH('TEST') = 2) AS t1";
 
     assertThat(toSql(root, DatabaseProduct.CALCITE.getDialect()), isLinux(expectedSql));
     assertThat(toSql(root, DatabaseProduct.BIG_QUERY.getDialect()), isLinux(expectedBiqQuery));


### PR DESCRIPTION
Added support to create a subquery if the In-clause subquery has function call in group by clause. 
In case of In-subquery with group by and having clause , alias generated by raven for the function call was not getting resolved.