### PR TITLE
Spark Time to Timestamp cast

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/dialect/SparkSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/SparkSqlDialect.java
@@ -42,6 +42,7 @@ import org.apache.calcite.sql.SqlSyntax;
 import org.apache.calcite.sql.SqlUtil;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.fun.SqlFloorFunction;
+import org.apache.calcite.sql.fun.SqlLibraryOperators;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.parser.CurrentTimestampHandler;
 import org.apache.calcite.sql.parser.SqlParserPos;
@@ -51,6 +52,7 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.CastCallBuilder;
 import org.apache.calcite.util.PaddingFunctionUtil;
 import org.apache.calcite.util.TimeString;
+import org.apache.calcite.util.TimestampString;
 import org.apache.calcite.util.ToNumberUtils;
 import org.apache.calcite.util.interval.SparkDateTimestampInterval;
 
@@ -95,6 +97,7 @@ import static org.apache.calcite.sql.fun.SqlLibraryOperators.DATE_FORMAT;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.FROM_UNIXTIME;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.RAISE_ERROR;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.SPLIT;
+import static org.apache.calcite.sql.fun.SqlLibraryOperators.TO_DATE;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.UNIX_TIMESTAMP;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.CAST;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.FLOOR;
@@ -120,6 +123,8 @@ public class SparkSqlDialect extends SqlDialect {
       new SqlFunction("SUBSTRING", SqlKind.OTHER_FUNCTION,
           ReturnTypes.ARG0_NULLABLE_VARYING, null, null,
           SqlFunctionCategory.STRING);
+
+  private static final String DEFAULT_DATE_FOR_TIME = "1970-01-01";
 
   private static final Map<SqlDateTimeFormat, String> DATE_TIME_FORMAT_MAP =
       new HashMap<SqlDateTimeFormat, String>() {{
@@ -240,18 +245,17 @@ public class SparkSqlDialect extends SqlDialect {
       return new CastCallBuilder(this).makCastCallForTimestampWithPrecision(operandToCast,
           castTo.getPrecision());
     } else if (castTo.getSqlTypeName() == SqlTypeName.TIME) {
-      if (castFrom.getSqlTypeName() == SqlTypeName.TIMESTAMP) {
-        return new CastCallBuilder(this)
-            .makCastCallForTimeWithPrecision(operandToCast, castTo.getPrecision());
-      }
-      return operandToCast;
+      return new CastCallBuilder(this)
+          .makeCastCallForTimeWithTimestamp(operandToCast, castTo.getPrecision());
     }
     return super.getCastCall(operandToCast, castFrom, castTo);
   }
 
   @Override public SqlNode getTimeLiteral(
       TimeString timeString, int precision, SqlParserPos pos) {
-    return SqlLiteral.createCharString(timeString.toString(), SqlParserPos.ZERO);
+    return SqlLiteral.createTimestamp(
+        new TimestampString(DEFAULT_DATE_FOR_TIME + " " + timeString),
+        precision, SqlParserPos.ZERO);
   }
 
   @Override public void unparseCall(final SqlWriter writer, final SqlCall call,
@@ -562,6 +566,9 @@ public class SparkSqlDialect extends SqlDialect {
       SqlCall errorCall = RAISE_ERROR.createCall(SqlParserPos.ZERO, (SqlNode) call.operand(0));
       super.unparseCall(writer, errorCall, leftPrec, rightPrec);
       break;
+    case "CURRENT_TIME":
+      unparseCurrentTime(writer, call, leftPrec, rightPrec);
+      break;
     default:
       super.unparseCall(writer, call, leftPrec, rightPrec);
     }
@@ -604,6 +611,14 @@ public class SparkSqlDialect extends SqlDialect {
     unparseCall(writer, plusNode, leftPrec, rightPrec);
   }
 
+  private void unparseCurrentTime(SqlWriter writer, SqlCall call, int leftPrec, int rightPrec) {
+    int precision = Integer.parseInt(((SqlLiteral) call.operand(0)).getValue().toString());
+    SqlCall timeStampCastCall = new CastCallBuilder(this)
+        .makeCastCallForTimeWithTimestamp(
+            SqlLibraryOperators.CURRENT_TIMESTAMP.createCall(SqlParserPos.ZERO), precision);
+    unparseCall(writer, timeStampCastCall, leftPrec, rightPrec);
+  }
+
   private SqlCharStringLiteral creteDateTimeFormatSqlCharLiteral(String format) {
     String formatString = getDateTimeFormatString(unquoteStringLiteral(format),
         DATE_TIME_FORMAT_MAP);
@@ -621,7 +636,10 @@ public class SparkSqlDialect extends SqlDialect {
       switch (typeName) {
       case INTEGER:
         return createSqlDataTypeSpecByName("INT", typeName);
+      case TIME:
+      case TIME_WITH_LOCAL_TIME_ZONE:
       case TIMESTAMP:
+      case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
         return createSqlDataTypeSpecByName("TIMESTAMP", typeName);
       default:
         break;

--- a/core/src/main/java/org/apache/calcite/sql/dialect/SparkSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/SparkSqlDialect.java
@@ -97,7 +97,6 @@ import static org.apache.calcite.sql.fun.SqlLibraryOperators.DATE_FORMAT;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.FROM_UNIXTIME;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.RAISE_ERROR;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.SPLIT;
-import static org.apache.calcite.sql.fun.SqlLibraryOperators.TO_DATE;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.UNIX_TIMESTAMP;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.CAST;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.FLOOR;
@@ -612,7 +611,10 @@ public class SparkSqlDialect extends SqlDialect {
   }
 
   private void unparseCurrentTime(SqlWriter writer, SqlCall call, int leftPrec, int rightPrec) {
-    int precision = Integer.parseInt(((SqlLiteral) call.operand(0)).getValue().toString());
+    int precision = 0;
+    if (call.operandCount() == 1) {
+      precision = Integer.parseInt(((SqlLiteral) call.operand(0)).getValue().toString());
+    }
     SqlCall timeStampCastCall = new CastCallBuilder(this)
         .makeCastCallForTimeWithTimestamp(
             SqlLibraryOperators.CURRENT_TIMESTAMP.createCall(SqlParserPos.ZERO), precision);

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -730,7 +730,7 @@ public abstract class SqlLibraryOperators {
 
   /** The "TO_DATE(string1, string2)" function; casts string1
    * to a DATE using the format specified in string2. */
-  @LibraryOperator(libraries = {POSTGRESQL, ORACLE})
+  @LibraryOperator(libraries = {POSTGRESQL, ORACLE, SPARK})
   public static final SqlFunction TO_DATE =
       new SqlFunction("TO_DATE",
           SqlKind.OTHER_FUNCTION,

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -730,7 +730,7 @@ public abstract class SqlLibraryOperators {
 
   /** The "TO_DATE(string1, string2)" function; casts string1
    * to a DATE using the format specified in string2. */
-  @LibraryOperator(libraries = {POSTGRESQL, ORACLE, SPARK})
+  @LibraryOperator(libraries = {POSTGRESQL, ORACLE})
   public static final SqlFunction TO_DATE =
       new SqlFunction("TO_DATE",
           SqlKind.OTHER_FUNCTION,

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -7928,13 +7928,15 @@ class RelToSqlConverterTest {
         + "FROM \"foodmart\".\"employee\"";
     final String expected = "SELECT SPLIT(DATE_FORMAT(hire_date, 'yyyy-MM-dd HH:mm:ss'), ' ')[1]\n"
         + "FROM foodmart.employee";
+    final String expectedSpark = "SELECT CAST('1970-01-01 ' || DATE_FORMAT(hire_date, 'HH:mm:ss') "
+        + "AS TIMESTAMP)\nFROM foodmart.employee";
     final String expectedBigQuery = "SELECT CAST(hire_date AS TIME)\n"
         + "FROM foodmart.employee";
     sql(query)
         .withHive()
         .ok(expected)
         .withSpark()
-        .ok(expected)
+        .ok(expectedSpark)
         .withBigQuery()
         .ok(expectedBigQuery);
   }
@@ -7945,8 +7947,8 @@ class RelToSqlConverterTest {
     final String expectedHive = "SELECT SPLIT(DATE_FORMAT(hire_date, 'yyyy-MM-dd HH:mm:ss.sss'), "
         + "' ')[1]\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT SPLIT(DATE_FORMAT(hire_date, 'yyyy-MM-dd HH:mm:ss.SSS'),"
-        + " ' ')[1]\nFROM foodmart.employee";
+    final String expectedSpark = "SELECT CAST('1970-01-01 ' || DATE_FORMAT(hire_date, 'HH:mm:ss"
+        + ".SSS') AS TIMESTAMP)\nFROM foodmart.employee";
     final String expectedBigQuery = "SELECT CAST(FORMAT_TIME('%H:%M:%E3S', CAST(hire_date AS TIME))"
         + " AS TIME)\n"
         + "FROM foodmart.employee";
@@ -7964,8 +7966,8 @@ class RelToSqlConverterTest {
         + "FROM \"foodmart\".\"employee\"";
     final String expectedHive = "SELECT CONCAT('12:00', ':05')\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = "SELECT '12:00' || ':05'\n"
-        + "FROM foodmart.employee";
+    final String expectedSpark = "SELECT CAST('1970-01-01 ' || "
+        + "DATE_FORMAT('12:00' || ':05', 'HH:mm:ss.SSS') AS TIMESTAMP)\nFROM foodmart.employee";
     final String expectedBigQuery = "SELECT CAST(FORMAT_TIME('%H:%M:%E3S', CAST(CONCAT('12:00', "
         + "':05') AS TIME)) AS TIME)\n"
         + "FROM foodmart.employee";
@@ -7987,7 +7989,8 @@ class RelToSqlConverterTest {
         + "FROM \"foodmart\".\"employee\"";
     final String expectedHive = "SELECT '12:00:05'\n"
         + "FROM foodmart.employee";
-    final String expectedSpark = expectedHive;
+    final String expectedSpark = "SELECT TIMESTAMP '1970-01-01 12:00:05.000'\n"
+        + "FROM foodmart.employee";
     final String expectedBigQuery = "SELECT TIME '12:00:05.000'\n"
         + "FROM foodmart.employee";
     sql(query)
@@ -7997,6 +8000,16 @@ class RelToSqlConverterTest {
         .ok(expectedSpark)
         .withBigQuery()
         .ok(expectedBigQuery);
+  }
+
+  @Test public void testCastToTimeWithPrecisionWithTimeZoneStringLiteral() {
+    String query = "SELECT cast('12:00:05+08:30' as TIME(3)) "
+        + "FROM \"foodmart\".\"employee\"";
+    final String expectedSpark =  "SELECT CAST('1970-01-01 ' || "
+        + "DATE_FORMAT('12:00:05+08:30', 'HH:mm:ss.SSS') AS TIMESTAMP)\nFROM foodmart.employee";
+    sql(query)
+        .withSpark()
+        .ok(expectedSpark);
   }
 
   @Test public void testFormatDateRelToSql() {
@@ -8159,7 +8172,8 @@ class RelToSqlConverterTest {
         + "UNIX_TIMESTAMP('20181106', 'yyyyMMdd'), 'yyyy-MM-dd') AS DATE) date1, "
         + "CAST(FROM_UNIXTIME(UNIX_TIMESTAMP('2018/11/06', 'yyyy/MM/dd'), 'yyyy-MM-dd') AS DATE) date2\n"
         + "FROM scott.EMP";
-    final String expectedSpark = expectedHive;
+    final String expectedSpark = "SELECT TO_DATE('20181106', 'yyyyMMdd') date1, TO_DATE"
+        + "('2018/11/06', 'yyyy/MM/dd') date2\nFROM scott.EMP";
     final String expectedSnowflake =
         "SELECT TO_DATE('20181106', 'YYYYMMDD') AS \"date1\", "
         + "TO_DATE('2018/11/06', 'YYYY/MM/DD') AS \"date2\"\n"
@@ -10192,5 +10206,15 @@ class RelToSqlConverterTest {
         + "FROM scott.EMP";
     assertThat(toSql(root, DatabaseProduct.CALCITE.getDialect()), isLinux(expectedSql));
     assertThat(toSql(root, DatabaseProduct.BIG_QUERY.getDialect()), isLinux(expectedBiqQuery));
+  }
+
+  @Test public void testForSparkCurrentTime() {
+    String query = "SELECT CURRENT_TIME(2) > '08:00:00'"
+        + "FROM \"foodmart\".\"employee\"";
+    final String expectedSpark = "SELECT CAST('1970-01-01 ' || "
+        + "DATE_FORMAT(CURRENT_TIMESTAMP, 'HH:mm:ss.SS') AS TIMESTAMP)\nFROM foodmart.employee";
+    sql(query)
+        .withSpark()
+        .ok(expectedSpark);
   }
 }

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -8172,8 +8172,7 @@ class RelToSqlConverterTest {
         + "UNIX_TIMESTAMP('20181106', 'yyyyMMdd'), 'yyyy-MM-dd') AS DATE) date1, "
         + "CAST(FROM_UNIXTIME(UNIX_TIMESTAMP('2018/11/06', 'yyyy/MM/dd'), 'yyyy-MM-dd') AS DATE) date2\n"
         + "FROM scott.EMP";
-    final String expectedSpark = "SELECT TO_DATE('20181106', 'yyyyMMdd') date1, TO_DATE"
-        + "('2018/11/06', 'yyyy/MM/dd') date2\nFROM scott.EMP";
+    final String expectedSpark = expectedHive;
     final String expectedSnowflake =
         "SELECT TO_DATE('20181106', 'YYYYMMDD') AS \"date1\", "
         + "TO_DATE('2018/11/06', 'YYYY/MM/DD') AS \"date2\"\n"
@@ -10209,10 +10208,13 @@ class RelToSqlConverterTest {
   }
 
   @Test public void testForSparkCurrentTime() {
-    String query = "SELECT CURRENT_TIME(2) > '08:00:00'"
+    String query = "SELECT CURRENT_TIME(2) > '08:00:00', "
+        + "CAST(\"hire_date\" AS TIME(4)) = '00:00:00'"
         + "FROM \"foodmart\".\"employee\"";
-    final String expectedSpark = "SELECT CAST('1970-01-01 ' || "
-        + "DATE_FORMAT(CURRENT_TIMESTAMP, 'HH:mm:ss.SS') AS TIMESTAMP)\nFROM foodmart.employee";
+    final String expectedSpark = "SELECT CAST('1970-01-01 ' || DATE_FORMAT(CURRENT_TIMESTAMP, "
+        + "'HH:mm:ss.SS') AS TIMESTAMP) > TIMESTAMP '1970-01-01 08:00:00.00', "
+        + "CAST('1970-01-01 ' || DATE_FORMAT(hire_date, 'HH:mm:ss.SSS') AS TIMESTAMP) = "
+        + "TIMESTAMP '1970-01-01 00:00:00.000'\nFROM foodmart.employee";
     sql(query)
         .withSpark()
         .ok(expectedSpark);


### PR DESCRIPTION
As Spark does not have a Time Datatype Time is converted to TimeStamp with a default date of 1970-01-01