### PR TITLE
Parse given input args as Timestamp for given time format for Cast fu…

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/dialect/SparkSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/SparkSqlDialect.java
@@ -726,7 +726,15 @@ public class SparkSqlDialect extends SqlDialect {
         super.unparseCall(writer, call, leftPrec, rightPrec);
       }
       return;
-
+    case "PARSE_TIMESTAMP":
+      formatString =
+              creteDateTimeFormatSqlCharLiteral(call.operand(0).toString());
+      SqlWriter.Frame castToTimestampFrame = writer.startFunCall("TO_TIMESTAMP");
+      call.operand(1).unparse(writer, leftPrec, rightPrec);
+      writer.sep(",", true);
+      formatString.unparse(writer, leftPrec, rightPrec);
+      writer.endFunCall(castToTimestampFrame);
+      break;
     default:
       super.unparseCall(writer, call, leftPrec, rightPrec);
     }

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -935,7 +935,7 @@ public abstract class SqlLibraryOperators {
           OperandTypes.STRING_STRING,
           SqlFunctionCategory.TIMEDATE);
 
-  @LibraryOperator(libraries = {BIG_QUERY})
+  @LibraryOperator(libraries = {BIG_QUERY, SPARK})
   public static final SqlFunction PARSE_TIMESTAMP =
       new SqlFunction("PARSE_TIMESTAMP",
         SqlKind.OTHER_FUNCTION,


### PR DESCRIPTION
Parse given input args as Timestamp for given time format for Cast function call. For that I added equivalent query 
For Big query equivalent function is PARSE_DATETIME and for TdSpark/databricks equivalent function is TO_TIMESTAMP