### PR TITLE
Fix for- No suitable driver found for jdbc:calcite

### DIFF
--- a/core/src/main/java/org/apache/calcite/tools/Frameworks.java
+++ b/core/src/main/java/org/apache/calcite/tools/Frameworks.java
@@ -18,6 +18,7 @@ package org.apache.calcite.tools;
 
 import org.apache.calcite.config.CalciteConnectionProperty;
 import org.apache.calcite.jdbc.CalciteSchema;
+import org.apache.calcite.jdbc.Driver;
 import org.apache.calcite.materialize.SqlStatisticProvider;
 import org.apache.calcite.plan.Context;
 import org.apache.calcite.plan.Contexts;
@@ -42,21 +43,29 @@ import org.apache.calcite.sql2rel.StandardConvertletTable;
 import org.apache.calcite.statistic.QuerySqlStatisticProvider;
 import org.apache.calcite.util.Util;
 
+import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.sql.Connection;
-import java.sql.DriverManager;
 import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.function.Supplier;
 
 /**
  * Tools for invoking Calcite functionality without initializing a container /
  * server first.
  */
 public class Frameworks {
+  
+  /**
+   * Caches an instance of the JDBC driver.
+   */
+  private static final Supplier<Driver> DRIVER_SUPPLIER =
+      Suppliers.memoize(Driver::new);
+
   private Frameworks() {
   }
 
@@ -174,11 +183,14 @@ public class Frameworks {
         info.setProperty(CalciteConnectionProperty.TYPE_SYSTEM.camelName(),
             config.getTypeSystem().getClass().getName());
       }
-      Connection connection =
-          DriverManager.getConnection("jdbc:calcite:", info);
-      final CalciteServerStatement statement =
-          connection.createStatement()
-              .unwrap(CalciteServerStatement.class);
+      // Connect via a Driver instance. Don't use DriverManager because driver
+      // auto-loading can get broken by shading and jar-repacking.
+      //  DriverManager.getConnection("jdbc:calcite:", info);
+      final CalciteServerStatement statement;
+      try (Connection connection = DRIVER_SUPPLIER.get().connect("jdbc:calcite:", info)) {
+        statement = connection.createStatement()
+            .unwrap(CalciteServerStatement.class);
+      }
       return new CalcitePrepareImpl().perform(statement, config, action);
     } catch (Exception e) {
       throw new RuntimeException(e);


### PR DESCRIPTION
[CALCITE-4760] RelBuilder creation fails with error 'No suitable driver found for jdbc:calcite:' in shaded Calcite Issues caused by jar-packaging/shading.

https://github.com/julianhyde/calcite/commit/2b830d80f6e4ac9b0efeead7c0542be2fdfd573d