### PR TITLE
RNBS-1210-adds-support-to-keep-where-clause-as-is-if-analytic-function-is-used-in-filter-rel

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
@@ -341,7 +341,9 @@ public class RelToSqlConverter extends SqlImplementor
   public Result visit(Filter e) {
     RelToSqlUtils relToSqlUtils = new RelToSqlUtils();
     final RelNode input = e.getInput();
-    if (dialect.supportsQualifyClause() && relToSqlUtils.hasAnalyticalFunctionInFilter(e)) {
+    if (dialect.supportsQualifyClause() && relToSqlUtils.hasAnalyticalFunctionInFilter(e)
+        && !(input instanceof LogicalJoin)) {
+      // need to keep where clause as is if input rel of the filter rel is a LogicalJoin
       // ignoreClauses will always be true because in case of false, new select wrap gets applied
       // with this current Qualify filter e. So, the input query won't remain as it is.
       final Result x = visitInput(e, 0, isAnon(), true,

--- a/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
@@ -692,9 +692,9 @@ public class BigQuerySqlDialect extends SqlDialect {
       }
       break;
     case IN:
-      if (call.operand(0) instanceof SqlLiteral &&
-          call.operand(1) instanceof SqlNodeList &&
-          ((SqlNodeList) call.operand(1)).get(0).getKind() == SqlKind.UNNEST) {
+      if (call.operand(0) instanceof SqlLiteral
+          && call.operand(1) instanceof SqlNodeList
+          && ((SqlNodeList) call.operand(1)).get(0).getKind() == SqlKind.UNNEST) {
         call.operand(0).unparse(writer, leftPrec, rightPrec);
         writer.print("IN");
         writer.setNeedWhitespace(true);

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -11069,10 +11069,8 @@ class RelToSqlConverterTest {
     assertThat(toSql(root, DatabaseProduct.BIG_QUERY.getDialect()), isLinux(expectedBigQuery));
   }
 
-  /*
-   * Unparsing "ABC" IN(UNNEST(ARRAY("ABC", "XYZ"))) --> "ABC" IN UNNEST(ARRAY["ABC", "XYZ"])
-   * */
-  @Test public void InUnnestSqlNode() {
+  @Test public void inUnnestSqlNode() {
+    // Unparsing "ABC" IN(UNNEST(ARRAY("ABC", "XYZ"))) --> "ABC" IN UNNEST(ARRAY["ABC", "XYZ"])
     final RelBuilder builder = relBuilder();
     RexNode arrayRex = builder.call(SqlStdOperatorTable.ARRAY_VALUE_CONSTRUCTOR,
         builder.literal("ABC"), builder.literal("XYZ"));
@@ -11083,12 +11081,13 @@ class RelToSqlConverterTest {
         .scan("EMP")
         .project(builder.alias(createRexNode, "array_contains"))
         .build();
-    final String expectedBiqQuery = "SELECT 'ABC' IN UNNEST(ARRAY['ABC', 'XYZ']) " +
-        "AS array_contains\n" + "FROM scott.EMP";
+    final String expectedBiqQuery = "SELECT 'ABC' IN UNNEST(ARRAY['ABC', 'XYZ']) "
+        + "AS array_containsn"
+        + "FROM scott.EMP";
     assertThat(toSql(root, DatabaseProduct.BIG_QUERY.getDialect()), isLinux(expectedBiqQuery));
   }
 
-  @Test public void RowNumberOverFunctionAsWhereClauseInJoin() {
+  @Test public void rowNumberOverFunctionAsWhereClauseInJoin() {
     String query = " select \"A\".\"product_id\"\n"
         + "    from (select \"product_id\", ROW_NUMBER() OVER (ORDER BY \"product_id\") AS RNK from \"product\") A\n"
         + "    cross join \"sales_fact_1997\"\n"


### PR DESCRIPTION
adds support to keep where clause as-is if analytic function is used in filter rel and the input node of filter rel is a logical join.