### PR TITLE
RTP_226_Conversion_Of_Coalesce

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/dialect/SparkSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/SparkSqlDialect.java
@@ -59,6 +59,7 @@ import org.apache.calcite.util.interval.SparkDateTimestampInterval;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
@@ -981,5 +982,14 @@ public class SparkSqlDialect extends SqlDialect {
           POST_MERIDIAN_INDICATOR.value);
     }
     return dateString;
+  }
+
+  @Override protected void unparseFormat(
+      final SqlWriter writer,
+      final SqlCall call, final int leftPrec, final int rightPrec) {
+    final SqlWriter.Frame formatFrame = writer.startFunCall("STRING");
+    List<SqlNode> operands = call.getOperandList();
+    operands.get(1).unparse(writer, leftPrec, rightPrec);
+    writer.endFunCall(formatFrame);
   }
 }

--- a/core/src/main/java/org/apache/calcite/sql/dialect/SparkSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/SparkSqlDialect.java
@@ -59,7 +59,6 @@ import org.apache.calcite.util.interval.SparkDateTimestampInterval;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
@@ -987,9 +986,10 @@ public class SparkSqlDialect extends SqlDialect {
   @Override protected void unparseFormat(
       final SqlWriter writer,
       final SqlCall call, final int leftPrec, final int rightPrec) {
+    /* We are unparsing FORMAT() as STRING() for databricks because of
+     different behaviour for NULL as argument */
     final SqlWriter.Frame formatFrame = writer.startFunCall("STRING");
-    List<SqlNode> operands = call.getOperandList();
-    operands.get(1).unparse(writer, leftPrec, rightPrec);
+    call.getOperandList().get(1).unparse(writer, leftPrec, rightPrec);
     writer.endFunCall(formatFrame);
   }
 }

--- a/core/src/main/java/org/apache/calcite/sql/dialect/SparkSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/SparkSqlDialect.java
@@ -59,7 +59,6 @@ import org.apache.calcite.util.interval.SparkDateTimestampInterval;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
@@ -83,6 +82,7 @@ import static org.apache.calcite.sql.fun.SqlStdOperatorTable.MINUS;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.MULTIPLY;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.PLUS;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.RAND;
+import static org.apache.calcite.util.Util.isFormatSqlBasicCall;
 import static org.apache.calcite.util.Util.modifyRegexStringForMatchArgument;
 
 import static  org.apache.calcite.sql.SqlDateTimeFormat.ABBREVIATEDMONTH;
@@ -1004,10 +1004,5 @@ public class SparkSqlDialect extends SqlDialect {
     final SqlWriter.Frame stringFrame = writer.startFunCall("STRING");
     ((SqlCall) call).operand(1).unparse(writer, 0, 0);
     writer.endFunCall(stringFrame);
-  }
-
-  private boolean isFormatSqlBasicCall(SqlNode sqlNode) {
-    return sqlNode instanceof SqlBasicCall && ((SqlBasicCall) sqlNode).getOperator()
-        .toString().equals("FORMAT");
   }
 }

--- a/core/src/main/java/org/apache/calcite/util/Util.java
+++ b/core/src/main/java/org/apache/calcite/util/Util.java
@@ -27,6 +27,7 @@ import org.apache.calcite.sql.SqlCharStringLiteral;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlBasicCall;
 import org.apache.calcite.sql.SqlValuesOperator;
 import org.apache.calcite.sql.fun.SqlRowOperator;
 import org.apache.calcite.sql.parser.SqlParserPos;
@@ -2912,5 +2913,10 @@ public class Util {
     String updatedRegexForI = matchArgumentRegexLiteral.concat(
         removeLeadingAndTrailingSingleQuotes(call.operand(1).toString()));
     return SqlLiteral.createCharString(updatedRegexForI, SqlParserPos.ZERO);
+  }
+
+  public static boolean isFormatSqlBasicCall(SqlNode sqlNode) {
+    return sqlNode instanceof SqlBasicCall && ((SqlBasicCall) sqlNode).getOperator()
+        .toString().equals(SqlKind.FORMAT.name());
   }
 }

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -11268,15 +11268,15 @@ class RelToSqlConverterTest {
   @Test public void testCoalesceFunctionWithIntegerAndStringArgument() {
     final RelBuilder builder = relBuilder();
 
-    final RexNode formatIntegerCastRexNode =
+    final RexNode formatIntegerRexNode =
         builder.call(SqlLibraryOperators.FORMAT,
             builder.literal("'%11d'"), builder.scan("EMP").field(0));
-    final RexNode formatIntegerRexNode =
+    final RexNode formatCoalesceRexNode =
         builder.call(SqlStdOperatorTable.COALESCE,
-            formatIntegerCastRexNode, builder.scan("EMP").field(1));
+            formatIntegerRexNode, builder.scan("EMP").field(1));
     final RelNode root = builder
         .scan("EMP")
-        .project(builder.alias(formatIntegerRexNode, "Name"))
+        .project(builder.alias(formatCoalesceRexNode, "Name"))
         .build();
 
     final String expectedSparkQuery = "SELECT "
@@ -11288,15 +11288,15 @@ class RelToSqlConverterTest {
   @Test public void testCoalesceFunctionWithDecimalAndStringArgument() {
     final RelBuilder builder = relBuilder();
 
-    final RexNode formatIntegerCastRexNode =
+    final RexNode formatFloatRexNode =
         builder.call(SqlLibraryOperators.FORMAT,
             builder.literal("'%10.4f'"), builder.scan("EMP").field(5));
-    final RexNode formatIntegerRexNode =
+    final RexNode formatCoalesceRexNode =
         builder.call(SqlStdOperatorTable.COALESCE,
-            formatIntegerCastRexNode, builder.scan("EMP").field(1));
+            formatFloatRexNode, builder.scan("EMP").field(1));
     final RelNode root = builder
         .scan("EMP")
-        .project(builder.alias(formatIntegerRexNode, "Name"))
+        .project(builder.alias(formatCoalesceRexNode, "Name"))
         .build();
 
     final String expectedSparkQuery = "SELECT "


### PR DESCRIPTION
While translating a scenario where coalesce function was used on decimal field & replacement was given as string. raven translates its using PRINTF function but its not working on Databricks.