### PR TITLE
RNBS-1379-fixes-definition-of-TIME_ADD-function

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -480,7 +480,7 @@ public abstract class SqlLibraryOperators {
       new SqlFunction("TIME_ADD",
           SqlKind.PLUS,
           ReturnTypes.TIME, null,
-          OperandTypes.family(SqlTypeFamily.ANY, SqlTypeFamily.TIME),
+          OperandTypes.DATETIME_INTERVAL,
           SqlFunctionCategory.TIMEDATE) {
 
     @Override public void unparse(SqlWriter writer, SqlCall call, int leftPrec, int rightPrec) {


### PR DESCRIPTION
Made operandTypes of TIME_ADD to synonimous with TIME_SUB function in SQLLibraryOperators.java