### PR TITLE
RSFB-1141: added column comment related changes

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
@@ -410,7 +410,8 @@ public class BigQuerySqlDialect extends SqlDialect {
 
   @Override public void unparseTitleInColumnDefinition(SqlWriter writer, String title,
       int leftPrec, int rightPrec) {
-    title = title.replace("''", "\\'");
+    title = title.substring(1, title.length() - 1).replace("''", "\\'");
+    title = "'" + title + "'";
     writer.print("OPTIONS(description=" + title + ")");
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
@@ -411,9 +411,7 @@ public class BigQuerySqlDialect extends SqlDialect {
 
   @Override public void unparseTitleInColumnDefinition(SqlWriter writer, String title,
       int leftPrec, int rightPrec) {
-    if (COMMENT_REGEX.matcher(title).matches()) {
-      title = title.replace("''", "\\'");
-    }
+    title = title.replace("''", "\\'");
     writer.print("OPTIONS(description=" + title + ")");
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
@@ -410,10 +410,9 @@ public class BigQuerySqlDialect extends SqlDialect {
 
   @Override public void unparseTitleInColumnDefinition(SqlWriter writer, String title,
       int leftPrec, int rightPrec) {
-    title = title.replace("''", "\\'");
-    title = limitTitleLength(title);
     title = title.substring(1, title.length() - 1).replace("''", "\\'");
     title = "'" + title + "'";
+    title = limitTitleLength(title);
     writer.print("OPTIONS(description=" + title + ")");
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
@@ -410,8 +410,10 @@ public class BigQuerySqlDialect extends SqlDialect {
 
   @Override public void unparseTitleInColumnDefinition(SqlWriter writer, String title,
       int leftPrec, int rightPrec) {
+    char commentStart = title.charAt(0);
+    char commentEnd = title.charAt(title.length() - 1);
     title = title.substring(1, title.length() - 1).replace("''", "\\'");
-    title = "'" + title + "'";
+    title = commentStart + title + commentEnd;
     title = limitTitleLength(title);
     writer.print("OPTIONS(description=" + title + ")");
   }

--- a/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
@@ -216,7 +216,7 @@ public class BigQuerySqlDialect extends SqlDialect {
               "RESPECT", "RIGHT", "ROLLUP", "ROWS", "SELECT", "SET", "SOME",
               "STRUCT", "TABLESAMPLE", "THEN", "TO", "TREAT", "TRUE",
               "UNBOUNDED", "UNION", "UNNEST", "USING", "WHEN", "WHERE",
-              "WINDOW", "WITH", "WITHIN"));
+              "WINDOW", "WITH", "WITHIN", "CURRENT_TIMESTAMP"));
 
   /**
    * An unquoted BigQuery identifier must start with a letter and be followed

--- a/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
@@ -422,7 +422,7 @@ public class BigQuerySqlDialect extends SqlDialect {
    * BQ(description char length): The maximum length is 1024 characters.
    */
   String limitTitleLength(String title) {
-    return title.length() > 1024 ? title.substring(0, 1024) : title;
+    return title.length() > 1024 ? title.substring(0, 1023) + "'" : title;
   }
 
   @Override public boolean supportsUnpivot() {

--- a/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
@@ -228,9 +228,6 @@ public class BigQuerySqlDialect extends SqlDialect {
 
   private static final String TEMP_REGEX = "\\s?°([CcFf])";
 
-  private static final Pattern COMMENT_REGEX =
-      Pattern.compile(".*''.*''.*");
-
   private static final Pattern FLOAT_REGEX =
       Pattern.compile("[\"|'][+\\-]?([0-9]*[.])[0-9]+[\"|']");
   /**

--- a/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
@@ -227,6 +227,9 @@ public class BigQuerySqlDialect extends SqlDialect {
 
   private static final String TEMP_REGEX = "\\s?°([CcFf])";
 
+  private static final Pattern COMMENT_REGEX =
+      Pattern.compile(".*''.*''.*");
+
   private static final Pattern FLOAT_REGEX =
       Pattern.compile("[\"|'][+\\-]?([0-9]*[.])[0-9]+[\"|']");
   /**
@@ -408,6 +411,9 @@ public class BigQuerySqlDialect extends SqlDialect {
 
   @Override public void unparseTitleInColumnDefinition(SqlWriter writer, String title,
       int leftPrec, int rightPrec) {
+    if (COMMENT_REGEX.matcher(title).matches()) {
+      title = title.replace("''", "\\'");
+    }
     writer.print("OPTIONS(description=" + title + ")");
   }
 

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -6959,7 +6959,7 @@ class RelToSqlConverterTest {
     String query = "select current_timestamp";
     final String expectedHiveQuery = "SELECT CURRENT_TIMESTAMP `CURRENT_TIMESTAMP`";
     final String expectedSparkQuery = "SELECT CURRENT_TIMESTAMP `CURRENT_TIMESTAMP`";
-    final String expectedBigQuery = "SELECT CURRENT_DATETIME() AS CURRENT_TIMESTAMP";
+    final String expectedBigQuery = "SELECT CURRENT_DATETIME() AS `CURRENT_TIMESTAMP`";
 
     sql(query)
         .withHiveIdentifierQuoteString()


### PR DESCRIPTION
Added column comment related changes.
If comment contains two consecutive single quote, it should be retained.
Also this occurred in Create table statement, we could not add relative test case for that method.