### PR TITLE
[CALCITE-4443] Add ILIKE operator (as LIKE, but case-insensitive and …

### DIFF
--- a/babel/src/main/codegen/config.fmpp
+++ b/babel/src/main/codegen/config.fmpp
@@ -237,6 +237,7 @@ data: {
       "HOUR"
       "IDENTITY"
 #     "IF" # not a keyword in Calcite
+      "ILIKE"
       "IMMEDIATE"
       "IMMEDIATELY"
       "IMPORT"

--- a/core/src/main/codegen/default_config.fmpp
+++ b/core/src/main/codegen/default_config.fmpp
@@ -130,6 +130,7 @@ parser: {
     "HOP"
     "HOURS"
     "IGNORE"
+    "ILIKE"
     "IMMEDIATE"
     "IMMEDIATELY"
     "IMPLEMENTATION"

--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -3588,10 +3588,14 @@ List<Object> Expression2(ExprContext exprContext) :
                         (
                             <LIKE> { op = SqlStdOperatorTable.NOT_LIKE; }
                         |
+                            <ILIKE> { op = SqlLibraryOperators.NOT_ILIKE; }
+                        |
                             <SIMILAR> <TO> { op = SqlStdOperatorTable.NOT_SIMILAR_TO; }
                         )
                     |
                         <LIKE> { op = SqlStdOperatorTable.LIKE; }
+                    |
+                        <ILIKE> { op = SqlLibraryOperators.ILIKE; }
                     |
                         <SIMILAR> <TO> { op = SqlStdOperatorTable.SIMILAR_TO; }
                     )
@@ -7449,6 +7453,7 @@ SqlPostfixOperator PostfixRowOperator() :
 |   < HOURS: "HOURS" >
 |   < IDENTITY: "IDENTITY" >
 |   < IGNORE: "IGNORE" >
+|   < ILIKE: "ILIKE" >
 |   < IMMEDIATE: "IMMEDIATE" >
 |   < IMMEDIATELY: "IMMEDIATELY" >
 |   < IMPLEMENTATION: "IMPLEMENTATION" >

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
@@ -128,6 +128,7 @@ import static org.apache.calcite.sql.fun.SqlLibraryOperators.EXTRACT_VALUE;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.EXTRACT_XML;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.FORMAT;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.FROM_BASE64;
+import static org.apache.calcite.sql.fun.SqlLibraryOperators.ILIKE;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.IFNULL;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.INSTR;
 import static org.apache.calcite.sql.fun.SqlLibraryOperators.INT2SHL;
@@ -520,11 +521,15 @@ public class RexImpTable {
     map.put(IS_FALSE, new IsFalseImplementor());
     map.put(IS_NOT_FALSE, new IsNotFalseImplementor());
 
-    // LIKE and SIMILAR
+    // LIKE, ILIKE and SIMILAR
     final MethodImplementor likeImplementor =
         new MethodImplementor(BuiltInMethod.LIKE.method, NullPolicy.STRICT,
             false);
     map.put(LIKE, likeImplementor);
+    final MethodImplementor ilikeImplementor =
+        new MethodImplementor(BuiltInMethod.ILIKE.method, NullPolicy.STRICT,
+            false);
+    map.put(ILIKE, ilikeImplementor);
     final MethodImplementor similarImplementor =
         new MethodImplementor(BuiltInMethod.SIMILAR.method, NullPolicy.STRICT,
             false);

--- a/core/src/main/java/org/apache/calcite/rex/RexSimplify.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexSimplify.java
@@ -27,21 +27,30 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.SqlTypeCoercionRule;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.type.SqlTypeUtil;
 import org.apache.calcite.util.Bug;
 import org.apache.calcite.util.Pair;
+import org.apache.calcite.util.RangeSets;
+import org.apache.calcite.util.Sarg;
 import org.apache.calcite.util.Util;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.BoundType;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableRangeSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Range;
+import com.google.common.collect.RangeSet;
 import com.google.common.collect.Sets;
+import com.google.common.collect.TreeRangeSet;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.ArrayList;
+import java.util.BitSet;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -53,9 +62,12 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
+import static org.apache.calcite.linq4j.Nullness.castNonNull;
 import static org.apache.calcite.rex.RexUnknownAs.FALSE;
 import static org.apache.calcite.rex.RexUnknownAs.TRUE;
 import static org.apache.calcite.rex.RexUnknownAs.UNKNOWN;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * Context required to simplify a row-expression.
@@ -87,12 +99,12 @@ public class RexSimplify {
   private RexSimplify(RexBuilder rexBuilder, RelOptPredicateList predicates,
       RexUnknownAs defaultUnknownAs, boolean predicateElimination,
       boolean paranoid, RexExecutor executor) {
-    this.rexBuilder = Objects.requireNonNull(rexBuilder);
-    this.predicates = Objects.requireNonNull(predicates);
-    this.defaultUnknownAs = Objects.requireNonNull(defaultUnknownAs);
+    this.rexBuilder = requireNonNull(rexBuilder);
+    this.predicates = requireNonNull(predicates);
+    this.defaultUnknownAs = requireNonNull(defaultUnknownAs);
     this.predicateElimination = predicateElimination;
     this.paranoid = paranoid;
-    this.executor = Objects.requireNonNull(executor);
+    this.executor = requireNonNull(executor);
     this.strong = new Strong();
   }
 
@@ -175,6 +187,10 @@ public class RexSimplify {
     if (e2.getType() == e.getType()) {
       return e2;
     }
+    if (!matchNullability
+        && SqlTypeUtil.equalSansNullability(rexBuilder.typeFactory, e2.getType(), e.getType())) {
+      return e2;
+    }
     final RexNode e3 = rexBuilder.makeCast(e.getType(), e2, matchNullability);
     if (e3.equals(e)) {
       return e;
@@ -251,6 +267,8 @@ public class RexSimplify {
         case FALSE:
         case TRUE:
           return rexBuilder.makeLiteral(unknownAs.toBoolean());
+        default:
+          break;
         }
       }
       return rexBuilder.makeNullLiteral(e.getType());
@@ -286,6 +304,14 @@ public class RexSimplify {
     case LESS_THAN_OR_EQUAL:
     case NOT_EQUALS:
       return simplifyComparison((RexCall) e, unknownAs);
+    case SEARCH:
+      return simplifySearch((RexCall) e, unknownAs);
+    case LIKE:
+      return simplifyLike((RexCall) e);
+    case MINUS_PREFIX:
+      return simplifyUnaryMinus((RexCall) e, unknownAs);
+    case PLUS_PREFIX:
+      return simplifyUnaryPlus((RexCall) e, unknownAs);
     case IF:
       return simplifyIf((RexCall) e, unknownAs);
     case NVL:
@@ -311,6 +337,16 @@ public class RexSimplify {
     return rexBuilder.makeCall(e.getType(), e.getOperator(), operands);
   }
 
+  private RexNode simplifyLike(RexCall e) {
+    if (e.operands.get(1) instanceof RexLiteral) {
+      final RexLiteral literal = (RexLiteral) e.operands.get(1);
+      if ("%".equals(literal.getValueAs(String.class))) {
+        return rexBuilder.makeLiteral(true);
+      }
+    }
+    return simplifyGenericNode(e);
+  }
+
   // e must be a comparison (=, >, >=, <, <=, !=)
   private RexNode simplifyComparison(RexCall e, RexUnknownAs unknownAs) {
     //noinspection unchecked
@@ -327,7 +363,7 @@ public class RexSimplify {
     // Simplify "x <op> x"
     final RexNode o0 = operands.get(0);
     final RexNode o1 = operands.get(1);
-    if (o0.equals(o1)) {
+    if (o0.equals(o1) && RexUtil.isDeterministic(o0)) {
       RexNode newExpr;
       switch (e.getKind()) {
       case EQUALS:
@@ -374,6 +410,8 @@ public class RexSimplify {
               return rexBuilder.makeLiteral(true);
             }
             break;
+          default:
+            break;
           }
         }
         if (cmp.literal.isAlwaysFalse()) {
@@ -395,6 +433,8 @@ public class RexSimplify {
             if (!cmp.ref.getType().isNullable()) {
               return rexBuilder.makeLiteral(false);
             }
+            break;
+          default:
             break;
           }
         }
@@ -505,11 +545,19 @@ public class RexSimplify {
     // may be unknown), because if either of them were true we would have
     // stopped.
     RexSimplify simplify = this;
+
+    // 'doneTerms' prevents us from visiting a term in both first and second
+    // loops. If we did this, the second visit would have a predicate saying
+    // that 'term' is false. Effectively, we sort terms: visiting
+    // 'allowedAsPredicate' terms in the first loop, and
+    // non-'allowedAsPredicate' in the second. Each term is visited once.
+    final BitSet doneTerms = new BitSet();
     for (int i = 0; i < terms.size(); i++) {
       final RexNode t = terms.get(i);
-      if (!allowedAsPredicateDuringOrSimplification(t)) {
+      if (!simplify.allowedAsPredicateDuringOrSimplification(t)) {
         continue;
       }
+      doneTerms.set(i);
       final RexNode t2 = simplify.simplify(t, unknownAs);
       terms.set(i, t2);
       final RexNode inverse =
@@ -521,8 +569,8 @@ public class RexSimplify {
     }
     for (int i = 0; i < terms.size(); i++) {
       final RexNode t = terms.get(i);
-      if (allowedAsPredicateDuringOrSimplification(t)) {
-        continue;
+      if (doneTerms.get(i)) {
+        continue; // we visited this term in the first loop
       }
       terms.set(i, simplify.simplify(t, unknownAs));
     }
@@ -534,52 +582,38 @@ public class RexSimplify {
    */
   private boolean allowedAsPredicateDuringOrSimplification(final RexNode t) {
     Predicate predicate = Predicate.of(t);
-    if (predicate == null) {
-      return false;
-    }
-    /** Inequalities are not supported. */
-    SqlKind kind = t.getKind();
-    if (!SqlKind.COMPARISON.contains(kind)) {
-      return true;
-    }
-    switch (kind) {
-    case LESS_THAN:
-    case GREATER_THAN:
-    case GREATER_THAN_OR_EQUAL:
-    case LESS_THAN_OR_EQUAL:
-      return false;
-    default:
-      return true;
-    }
+    return predicate != null && predicate.allowedInOr(predicates);
   }
 
   private RexNode simplifyNot(RexCall call, RexUnknownAs unknownAs) {
     final RexNode a = call.getOperands().get(0);
+    final List<RexNode> newOperands;
     switch (a.getKind()) {
     case NOT:
       // NOT NOT x ==> x
       return simplify(((RexCall) a).getOperands().get(0), unknownAs);
+    case SEARCH:
+      // NOT SEARCH(x, Sarg[(-inf, 10) OR NULL) ==> SEARCH(x, Sarg[[10, +inf)])
+      final RexCall call2 = (RexCall) a;
+      final RexNode ref = call2.operands.get(0);
+      final RexLiteral literal = (RexLiteral) call2.operands.get(1);
+      final Sarg sarg = literal.getValueAs(Sarg.class);
+      return simplifySearch(
+          call2.clone(call2.type,
+              ImmutableList.of(ref,
+                  rexBuilder.makeLiteral(requireNonNull(sarg, "sarg").negate(), literal.getType(),
+                      literal.getTypeName()))),
+          unknownAs.negate());
     case LITERAL:
       if (a.getType().getSqlTypeName() == SqlTypeName.BOOLEAN
           && !RexLiteral.isNullLiteral(a)) {
         return rexBuilder.makeLiteral(!RexLiteral.booleanValue(a));
       }
-    }
-    final SqlKind negateKind = a.getKind().negate();
-    if (a.getKind() != negateKind) {
-      return simplify(
-          rexBuilder.makeCall(RexUtil.op(negateKind),
-              ((RexCall) a).getOperands()), unknownAs);
-    }
-    final SqlKind negateKind2 = a.getKind().negateNullSafe();
-    if (a.getKind() != negateKind2) {
-      return simplify(
-          rexBuilder.makeCall(RexUtil.op(negateKind2),
-              ((RexCall) a).getOperands()), unknownAs);
-    }
-    if (a.getKind() == SqlKind.AND) {
+      break;
+
+    case AND:
       // NOT distributivity for AND
-      final List<RexNode> newOperands = new ArrayList<>();
+      newOperands = new ArrayList<>();
       for (RexNode operand : ((RexCall) a).getOperands()) {
         newOperands.add(
             simplify(rexBuilder.makeCall(SqlStdOperatorTable.NOT, operand),
@@ -587,10 +621,10 @@ public class RexSimplify {
       }
       return simplify(
           rexBuilder.makeCall(SqlStdOperatorTable.OR, newOperands), unknownAs);
-    }
-    if (a.getKind() == SqlKind.OR) {
+
+    case OR:
       // NOT distributivity for OR
-      final List<RexNode> newOperands = new ArrayList<>();
+      newOperands = new ArrayList<>();
       for (RexNode operand : ((RexCall) a).getOperands()) {
         newOperands.add(
             simplify(rexBuilder.makeCall(SqlStdOperatorTable.NOT, operand),
@@ -598,21 +632,41 @@ public class RexSimplify {
       }
       return simplify(
           rexBuilder.makeCall(SqlStdOperatorTable.AND, newOperands), unknownAs);
-    }
-    if (a.getKind() == SqlKind.CASE) {
-      final List<RexNode> newOperands = new ArrayList<>();
+
+    case CASE:
+      newOperands = new ArrayList<>();
       List<RexNode> operands = ((RexCall) a).getOperands();
       for (int i = 0; i < operands.size(); i += 2) {
         if (i + 1 == operands.size()) {
-          newOperands.add(rexBuilder.makeCall(SqlStdOperatorTable.NOT, operands.get(i + 0)));
+          newOperands.add(rexBuilder.makeCall(SqlStdOperatorTable.NOT, operands.get(i)));
         } else {
-          newOperands.add(operands.get(i + 0));
+          newOperands.add(operands.get(i));
           newOperands.add(rexBuilder.makeCall(SqlStdOperatorTable.NOT, operands.get(i + 1)));
         }
       }
       return simplify(
           rexBuilder.makeCall(SqlStdOperatorTable.CASE, newOperands), unknownAs);
+
+    case IN:
+    case NOT_IN:
+      // do not try to negate
+      break;
+
+    default:
+      final SqlKind negateKind = a.getKind().negate();
+      if (a.getKind() != negateKind) {
+        return simplify(
+            rexBuilder.makeCall(RexUtil.op(negateKind),
+                ((RexCall) a).getOperands()), unknownAs);
+      }
+      final SqlKind negateKind2 = a.getKind().negateNullSafe();
+      if (a.getKind() != negateKind2) {
+        return simplify(
+            rexBuilder.makeCall(RexUtil.op(negateKind2),
+                ((RexCall) a).getOperands()), unknownAs);
+      }
     }
+
     RexNode a2 = simplify(a, unknownAs.negate());
     if (a == a2) {
       return call;
@@ -626,15 +680,32 @@ public class RexSimplify {
     return rexBuilder.makeCall(SqlStdOperatorTable.NOT, a2);
   }
 
+  private RexNode simplifyUnaryMinus(RexCall call, RexUnknownAs unknownAs) {
+    final RexNode a = call.getOperands().get(0);
+    if (a.getKind() == SqlKind.MINUS_PREFIX) {
+      // -(-(x)) ==> x
+      return simplify(((RexCall) a).getOperands().get(0), unknownAs);
+    }
+    return simplifyGenericNode(call);
+  }
+
+  private RexNode simplifyUnaryPlus(RexCall call, RexUnknownAs unknownAs) {
+    return simplify(call.getOperands().get(0), unknownAs);
+  }
+
   private RexNode simplifyIs(RexCall call, RexUnknownAs unknownAs) {
     final SqlKind kind = call.getKind();
     final RexNode a = call.getOperands().get(0);
+    final RexNode simplified = simplifyIs1(kind, a, unknownAs);
+    return simplified == null ? call : simplified;
+  }
 
+  private @Nullable RexNode simplifyIs1(SqlKind kind, RexNode a, RexUnknownAs unknownAs) {
     // UnknownAs.FALSE corresponds to x IS TRUE evaluation
     // UnknownAs.TRUE to x IS NOT FALSE
     // Note that both UnknownAs.TRUE and UnknownAs.FALSE only changes the meaning of Unknown
-    // (1) if we are already in UnknownAs.FALSE mode; x IS TRUE can be simiplified to x
-    // (2) similarily  in UnknownAs.TRUE mode ; x IS NOT FALSE can be simplified to x
+    // (1) if we are already in UnknownAs.FALSE mode; x IS TRUE can be simplified to x
+    // (2) similarly in UnknownAs.TRUE mode; x IS NOT FALSE can be simplified to x
     // (3) x IS FALSE could be rewritten to (NOT x) IS TRUE and from there the 1. rule applies
     // (4) x IS NOT TRUE can be rewritten to (NOT x) IS NOT FALSE and from there the 2. rule applies
     if (kind == SqlKind.IS_TRUE && unknownAs == RexUnknownAs.FALSE) {
@@ -654,14 +725,10 @@ public class RexSimplify {
       return pred;
     }
 
-    final RexNode simplified = simplifyIs2(kind, a, unknownAs);
-    if (simplified != null) {
-      return simplified;
-    }
-    return call;
+    return simplifyIs2(kind, a, unknownAs);
   }
 
-  private RexNode simplifyIsPredicate(SqlKind kind, RexNode a) {
+  private @Nullable RexNode simplifyIsPredicate(SqlKind kind, RexNode a) {
     if (!RexUtil.isReferenceOrAccess(a, true)) {
       return null;
     }
@@ -678,11 +745,12 @@ public class RexSimplify {
     return null;
   }
 
-  private RexNode simplifyIs2(SqlKind kind, RexNode a, RexUnknownAs unknownAs) {
+  private @Nullable RexNode simplifyIs2(SqlKind kind, RexNode a, RexUnknownAs unknownAs) {
     final RexNode simplified;
     switch (kind) {
     case IS_NULL:
       // x IS NULL ==> FALSE (if x is not nullable)
+      validateStrongPolicy(a);
       simplified = simplifyIsNull(a);
       if (simplified != null) {
         return simplified;
@@ -690,6 +758,7 @@ public class RexSimplify {
       break;
     case IS_NOT_NULL:
       // x IS NOT NULL ==> TRUE (if x is not nullable)
+      validateStrongPolicy(a);
       simplified = simplifyIsNotNull(a);
       if (simplified != null) {
         return simplified;
@@ -699,7 +768,7 @@ public class RexSimplify {
     case IS_NOT_FALSE:
       // x IS TRUE ==> x (if x is not nullable)
       // x IS NOT FALSE ==> x (if x is not nullable)
-      if (!a.getType().isNullable()) {
+      if (predicates.isEffectivelyNotNull(a)) {
         return simplify(a, unknownAs);
       } else {
         RexNode newSub =
@@ -713,9 +782,11 @@ public class RexSimplify {
     case IS_NOT_TRUE:
       // x IS NOT TRUE ==> NOT x (if x is not nullable)
       // x IS FALSE ==> NOT x (if x is not nullable)
-      if (!a.getType().isNullable()) {
+      if (predicates.isEffectivelyNotNull(a)) {
         return simplify(rexBuilder.makeCall(SqlStdOperatorTable.NOT, a), unknownAs);
       }
+      break;
+    default:
       break;
     }
     switch (a.getKind()) {
@@ -729,6 +800,8 @@ public class RexSimplify {
       final SqlOperator notKind = RexUtil.op(kind.negateNullSafe());
       final RexNode arg = ((RexCall) a).operands.get(0);
       return simplify(rexBuilder.makeCall(notKind, arg), UNKNOWN);
+    default:
+      break;
     }
     final RexNode a2 = simplify(a, UNKNOWN);
     if (a != a2) {
@@ -737,7 +810,7 @@ public class RexSimplify {
     return null; // cannot be simplified
   }
 
-  private RexNode simplifyIsNotNull(RexNode a) {
+  private @Nullable RexNode simplifyIsNotNull(RexNode a) {
     // Simplify the argument first,
     // call ourselves recursively to see whether we can make more progress.
     // For example, given
@@ -750,7 +823,7 @@ public class RexSimplify {
     if (predicates.pulledUpPredicates.contains(a)) {
       return rexBuilder.makeLiteral(true);
     }
-    if (a.getKind() == SqlKind.CAST) {
+    if (hasCustomNullabilityRules(a.getKind())) {
       return null;
     }
     switch (Strong.policy(a)) {
@@ -786,7 +859,7 @@ public class RexSimplify {
     }
   }
 
-  private RexNode simplifyIsNull(RexNode a) {
+  private @Nullable RexNode simplifyIsNull(RexNode a) {
     // Simplify the argument first,
     // call ourselves recursively to see whether we can make more progress.
     // For example, given
@@ -799,7 +872,7 @@ public class RexSimplify {
     if (RexUtil.isNull(a)) {
       return rexBuilder.makeLiteral(true);
     }
-    if (a.getKind() == SqlKind.CAST) {
+    if (hasCustomNullabilityRules(a.getKind())) {
       return null;
     }
     switch (Strong.policy(a)) {
@@ -822,6 +895,57 @@ public class RexSimplify {
     case AS_IS:
     default:
       return null;
+    }
+  }
+
+  /**
+   * Validates strong policy for specified {@link RexNode}.
+   *
+   * @param rexNode Rex node to validate the strong policy
+   * @throws AssertionError If the validation fails
+   */
+  private static void validateStrongPolicy(RexNode rexNode) {
+    if (hasCustomNullabilityRules(rexNode.getKind())) {
+      return;
+    }
+    switch (Strong.policy(rexNode)) {
+    case NOT_NULL:
+      assert !rexNode.getType().isNullable();
+      break;
+    case ANY:
+      List<RexNode> operands = ((RexCall) rexNode).getOperands();
+      if (rexNode.getType().isNullable()) {
+        assert operands.stream()
+            .map(RexNode::getType)
+            .anyMatch(RelDataType::isNullable);
+      } else {
+        assert operands.stream()
+            .map(RexNode::getType)
+            .noneMatch(RelDataType::isNullable);
+      }
+      break;
+    default:
+      break;
+    }
+  }
+
+  /**
+   * Returns {@code true} if specified {@link SqlKind} has custom nullability rules which
+   * depend not only on the nullability of input operands.
+   *
+   * <p>For example, CAST may be used to change the nullability of its operand type,
+   * so it may be nullable, though the argument type was non-nullable.
+   *
+   * @param sqlKind Sql kind to check
+   * @return {@code true} if specified {@link SqlKind} has custom nullability rules
+   */
+  private static boolean hasCustomNullabilityRules(SqlKind sqlKind) {
+    switch (sqlKind) {
+    case CAST:
+    case ITEM:
+      return true;
+    default:
+      return false;
     }
   }
 
@@ -946,7 +1070,7 @@ public class RexSimplify {
         }
       }
     }
-    List<RexNode> newOperands = CaseBranch.toCaseOperands(rexBuilder, branches);
+    List<RexNode> newOperands = CaseBranch.toCaseOperands(branches);
     if (newOperands.equals(call.getOperands())) {
       return call;
     }
@@ -957,7 +1081,7 @@ public class RexSimplify {
    * If boolean is true, simplify cond in input branch and return new branch.
    * Otherwise, simply return input branch.
    */
-  private CaseBranch generateBranch(boolean simplifyCond, RexSimplify simplifier,
+  private static CaseBranch generateBranch(boolean simplifyCond, RexSimplify simplifier,
       CaseBranch branch) {
     if (simplifyCond) {
       // the previous branch was merged, time to simplify it and
@@ -977,7 +1101,7 @@ public class RexSimplify {
             && oldType.isNullable());
   }
 
-  /** Object to describe a Case branch.*/
+  /** Object to describe a CASE branch. */
   static final class CaseBranch {
 
     private final RexNode cond;
@@ -1004,8 +1128,7 @@ public class RexSimplify {
       return ret;
     }
 
-    private static List<RexNode> toCaseOperands(RexBuilder rexBuilder,
-        List<CaseBranch> branches) {
+    private static List<RexNode> toCaseOperands(List<CaseBranch> branches) {
       List<RexNode> ret = new ArrayList<>();
       for (int i = 0; i < branches.size() - 1; i++) {
         CaseBranch branch = branches.get(i);
@@ -1020,11 +1143,12 @@ public class RexSimplify {
   }
 
   /**
-   * Decides whether it is safe to flatten the given case part into AND/ORs.
+   * Decides whether it is safe to flatten the given CASE part into ANDs/ORs.
    */
   enum SafeRexVisitor implements RexVisitor<Boolean> {
     INSTANCE;
 
+    @SuppressWarnings("ImmutableEnumChecker")
     private final Set<SqlKind> safeOps;
 
     SafeRexVisitor() {
@@ -1046,6 +1170,7 @@ public class RexSimplify {
       safeOps.add(SqlKind.IS_NOT_DISTINCT_FROM);
       safeOps.add(SqlKind.IN);
       safeOps.add(SqlKind.NOT_IN);
+      safeOps.add(SqlKind.SEARCH);
       safeOps.add(SqlKind.OR);
       safeOps.add(SqlKind.AND);
       safeOps.add(SqlKind.NOT);
@@ -1081,12 +1206,7 @@ public class RexSimplify {
       if (!safeOps.contains(call.getKind())) {
         return false;
       }
-      for (RexNode o : call.getOperands()) {
-        if (!o.accept(this)) {
-          return false;
-        }
-      }
-      return true;
+      return RexVisitorImpl.visitArrayAnd(this, call.operands);
     }
 
     @Override public Boolean visitOver(RexOver over) {
@@ -1135,8 +1255,9 @@ public class RexSimplify {
     return r.accept(SafeRexVisitor.INSTANCE);
   }
 
-  private static RexNode simplifyBooleanCase(RexBuilder rexBuilder,
-      List<CaseBranch> inputBranches, RexUnknownAs unknownAs, RelDataType branchType) {
+  private static @Nullable RexNode simplifyBooleanCase(RexBuilder rexBuilder,
+      List<CaseBranch> inputBranches, @SuppressWarnings("unused") RexUnknownAs unknownAs,
+      RelDataType branchType) {
     RexNode result;
 
     // prepare all condition/branches for boolean interpretation
@@ -1163,7 +1284,7 @@ public class RexSimplify {
       branches.add(new CaseBranch(cond, value));
     }
 
-    result = simplifyBooleanCaseGeneric(rexBuilder, branches, branchType);
+    result = simplifyBooleanCaseGeneric(rexBuilder, branches);
     return result;
   }
 
@@ -1182,7 +1303,7 @@ public class RexSimplify {
    * <pre>(p1 and x) or (p2 and y and not(p1)) or (true and z and not(p1) and not(p2))</pre>
    */
   private static RexNode simplifyBooleanCaseGeneric(RexBuilder rexBuilder,
-      List<CaseBranch> branches, RelDataType outputType) {
+      List<CaseBranch> branches) {
 
     boolean booleanBranches = branches.stream()
         .allMatch(branch -> branch.value.isAlwaysTrue() || branch.value.isAlwaysFalse());
@@ -1227,6 +1348,14 @@ public class RexSimplify {
     final List<RexNode> terms = new ArrayList<>();
     final List<RexNode> notTerms = new ArrayList<>();
 
+    final SargCollector sargCollector = new SargCollector(rexBuilder, true);
+    operands.forEach(t -> sargCollector.accept(t, terms));
+    if (sargCollector.needToFix(unknownAs)) {
+      operands.clear();
+      terms.forEach(t -> operands.add(sargCollector.fix(rexBuilder, t)));
+    }
+    terms.clear();
+
     for (RexNode o : operands) {
       RelOptUtil.decomposeConjunction(o, terms, notTerms);
     }
@@ -1234,6 +1363,8 @@ public class RexSimplify {
     switch (unknownAs) {
     case FALSE:
       return simplifyAnd2ForUnknownAsFalse(terms, notTerms, Comparable.class);
+    default:
+      break;
     }
     return simplifyAnd2(terms, notTerms);
   }
@@ -1436,6 +1567,9 @@ public class RexSimplify {
         if (comparison != null
             && comparison.kind != SqlKind.NOT_EQUALS) { // not supported yet
           final C constant = comparison.literal.getValueAs(clazz);
+          if (constant == null) {
+            break;
+          }
           final RexNode result = processRange(rexBuilder, terms, rangeTerms,
               term, comparison.ref, constant, comparison.kind);
           if (result != null) {
@@ -1457,6 +1591,9 @@ public class RexSimplify {
         break;
       case IS_NULL:
         nullOperands.add(((RexCall) term).getOperands().get(0));
+        break;
+      default:
+        break;
       }
     }
     // If one column should be null and is in a comparison predicate,
@@ -1528,8 +1665,13 @@ public class RexSimplify {
     return RexUtil.composeConjunction(rexBuilder, terms);
   }
 
+  @SuppressWarnings("BetaApi")
   private <C extends Comparable<C>> RexNode simplifyUsingPredicates(RexNode e,
       Class<C> clazz) {
+    if (predicates.pulledUpPredicates.isEmpty()) {
+      return e;
+    }
+
     final Comparison comparison = Comparison.of(e);
     // Check for comparison with null values
     if (comparison == null
@@ -1538,32 +1680,34 @@ public class RexSimplify {
       return e;
     }
     final C v0 = comparison.literal.getValueAs(clazz);
-    final Range<C> range = range(comparison.kind, v0);
-    final Range<C> range2 =
-        residue(comparison.ref, range, predicates.pulledUpPredicates,
+    if (v0 == null) {
+      return e;
+    }
+    final RangeSet<C> rangeSet = rangeSet(comparison.kind, v0);
+    final RangeSet<C> rangeSet2 =
+        residue(comparison.ref, rangeSet, predicates.pulledUpPredicates,
             clazz);
-    if (range2 == null) {
+    if (rangeSet2.isEmpty()) {
       // Term is impossible to satisfy given these predicates
       return rexBuilder.makeLiteral(false);
-    } else if (range2.equals(range)) {
+    } else if (rangeSet2.equals(rangeSet)) {
       // no change
       return e;
-    } else if (range2.equals(Range.all())) {
+    } else if (rangeSet2.equals(RangeSets.rangeSetAll())) {
       // Range is always satisfied given these predicates; but nullability might
       // be problematic
       return simplify(
           rexBuilder.makeCall(SqlStdOperatorTable.IS_NOT_NULL, comparison.ref),
           RexUnknownAs.UNKNOWN);
-    } else if (range2.lowerEndpoint().equals(range2.upperEndpoint())) {
-      if (range2.lowerBoundType() == BoundType.OPEN
-          || range2.upperBoundType() == BoundType.OPEN) {
-        // range is a point, but does not include its endpoint, therefore is
-        // effectively empty
-        return rexBuilder.makeLiteral(false);
-      }
+    } else if (rangeSet2.asRanges().size() == 1
+        && Iterables.getOnlyElement(rangeSet2.asRanges()).hasLowerBound()
+        && Iterables.getOnlyElement(rangeSet2.asRanges()).hasUpperBound()
+        && Iterables.getOnlyElement(rangeSet2.asRanges()).lowerEndpoint()
+        .equals(Iterables.getOnlyElement(rangeSet2.asRanges()).upperEndpoint())) {
+      final Range<C> r = Iterables.getOnlyElement(rangeSet2.asRanges());
       // range is now a point; it's worth simplifying
       return rexBuilder.makeCall(SqlStdOperatorTable.EQUALS, comparison.ref,
-          rexBuilder.makeLiteral(range2.lowerEndpoint(),
+          rexBuilder.makeLiteral(r.lowerEndpoint(),
               comparison.literal.getType(), comparison.literal.getTypeName()));
     } else {
       // range has been reduced but it's not worth simplifying
@@ -1584,11 +1728,14 @@ public class RexSimplify {
    * <li>{@code residue($0 < 10, [$0 < 20, $0 > 0])} returns {@code $0 < 10}
    * </ul>
    */
-  private <C extends Comparable<C>> Range<C> residue(RexNode ref, Range<C> r0,
-      List<RexNode> predicates, Class<C> clazz) {
+  @SuppressWarnings("BetaApi")
+  private static <C extends Comparable<C>> RangeSet<C> residue(RexNode ref,
+      RangeSet<C> r0, List<RexNode> predicates, Class<C> clazz) {
+    RangeSet<C> result = r0;
     for (RexNode predicate : predicates) {
       switch (predicate.getKind()) {
       case EQUALS:
+      case NOT_EQUALS:
       case LESS_THAN:
       case LESS_THAN_OR_EQUAL:
       case GREATER_THAN:
@@ -1598,21 +1745,40 @@ public class RexSimplify {
             && call.operands.get(1) instanceof RexLiteral) {
           final RexLiteral literal = (RexLiteral) call.operands.get(1);
           final C c1 = literal.getValueAs(clazz);
-          final Range<C> r1 = range(predicate.getKind(), c1);
-          if (r0.encloses(r1)) {
-            // Given these predicates, term is always satisfied.
-            // e.g. r0 is "$0 < 10", r1 is "$0 < 5"
-            return Range.all();
+          assert c1 != null : "value must not be null in " + literal;
+          switch (predicate.getKind()) {
+          case NOT_EQUALS:
+            // We want to intersect result with the range set of everything but
+            // c1. We subtract the point c1 from result, which is equivalent.
+            final Range<C> pointRange = range(SqlKind.EQUALS, c1);
+            final RangeSet<C> notEqualsRangeSet =
+                ImmutableRangeSet.of(pointRange).complement();
+            if (result.enclosesAll(notEqualsRangeSet)) {
+              result = RangeSets.rangeSetAll();
+              continue;
+            }
+            result = RangeSets.minus(result, pointRange);
+            break;
+          default:
+            final Range<C> r1 = range(predicate.getKind(), c1);
+            if (result.encloses(r1)) {
+              // Given these predicates, term is always satisfied.
+              // e.g. r0 is "$0 < 10", r1 is "$0 < 5"
+              result = RangeSets.rangeSetAll();
+              continue;
+            }
+            result = result.subRangeSet(r1);
           }
-          if (r0.isConnected(r1)) {
-            return r0.intersection(r1);
+          if (result.isEmpty()) {
+            break; // short-cut
           }
-          // Ranges do not intersect. Return null meaning the empty range.
-          return null;
         }
+        break;
+      default:
+        break;
       }
     }
-    return r0;
+    return result;
   }
 
   /** Simplifies OR(x, x) into x, and similar.
@@ -1625,10 +1791,13 @@ public class RexSimplify {
 
   private RexNode simplifyOr(RexCall call, RexUnknownAs unknownAs) {
     assert call.getKind() == SqlKind.OR;
-    final List<RexNode> terms = RelOptUtil.disjunctions(call);
+    final List<RexNode> terms0 = RelOptUtil.disjunctions(call);
+    final List<RexNode> terms;
     if (predicateElimination) {
+      terms = Util.moveToHead(terms0, e -> e.getKind() == SqlKind.IS_NULL);
       simplifyOrTerms(terms, unknownAs);
     } else {
+      terms = terms0;
       simplifyList(terms, unknownAs);
     }
     return simplifyOrs(terms, unknownAs);
@@ -1652,6 +1821,14 @@ public class RexSimplify {
   /** Simplifies a list of terms and combines them into an OR.
    * Modifies the list in place. */
   private RexNode simplifyOrs(List<RexNode> terms, RexUnknownAs unknownAs) {
+    final SargCollector sargCollector = new SargCollector(rexBuilder, false);
+    final List<RexNode> newTerms = new ArrayList<>();
+    terms.forEach(t -> sargCollector.accept(t, newTerms));
+    if (sargCollector.needToFix(unknownAs)) {
+      terms.clear();
+      newTerms.forEach(t -> terms.add(sargCollector.fix(rexBuilder, t)));
+    }
+
     // CALCITE-3198 Auxiliary map to simplify cases like:
     //   X <> A OR X <> B => X IS NOT NULL or NULL
     // The map key will be the 'X'; and the value the first call 'X<>A' that is found,
@@ -1694,10 +1871,12 @@ public class RexSimplify {
             //   - if it is not an IS_NOT_NULL (i.e. it is a NOT_EQUALS): check comparison values
             if (prevNotEquals.getKind() != SqlKind.IS_NOT_NULL) {
               final Comparable comparable1 = notEqualsComparison.literal.getValue();
-              //noinspection ConstantConditions
-              final Comparable comparable2 = Comparison.of(prevNotEquals).literal.getValue();
+              final Comparable comparable2 =
+                  castNonNull(Comparison.of(prevNotEquals)).literal.getValue();
               //noinspection unchecked
-              if (comparable1.compareTo(comparable2) != 0) {
+              if (comparable1 != null
+                  && comparable2 != null
+                  && comparable1.compareTo(comparable2) != 0) {
                 // X <> A OR X <> B => X IS NOT NULL OR NULL
                 final RexNode isNotNull =
                     rexBuilder.makeCall(SqlStdOperatorTable.IS_NOT_NULL, notEqualsComparison.ref);
@@ -1720,8 +1899,9 @@ public class RexSimplify {
           }
         }
         break;
+      default:
+        break;
       }
-      terms.set(i, term);
     }
     return RexUtil.composeDisjunction(rexBuilder, terms);
   }
@@ -1752,7 +1932,7 @@ public class RexSimplify {
     for (Map<RexNode, Comparable> map : foo0.assignments()) {
       for (RexNode predicate : predicates.pulledUpPredicates) {
         final Comparable v = RexInterpreter.evaluate(predicate, map);
-        if (!v.equals(true)) {
+        if (!Boolean.TRUE.equals(v)) {
           continue assignment_loop;
         }
       }
@@ -1774,6 +1954,9 @@ public class RexSimplify {
           if (v1 == NullSentinel.INSTANCE) {
             v1 = unknownAs.toBoolean();
           }
+          break;
+        default:
+          break;
         }
       }
       if (!v0.equals(v1)) {
@@ -1784,11 +1967,83 @@ public class RexSimplify {
     }
   }
 
+  private RexNode simplifySearch(RexCall call, RexUnknownAs unknownAs) {
+    assert call.getKind() == SqlKind.SEARCH;
+    final RexNode a = call.getOperands().get(0);
+    if (call.getOperands().get(1) instanceof RexLiteral) {
+      RexLiteral literal = (RexLiteral) call.getOperands().get(1);
+      final Sarg sarg = castNonNull(literal.getValueAs(Sarg.class));
+      // Remove null from sarg if the left-hand side is never null
+      if (sarg.containsNull) {
+        final RexNode simplified = simplifyIs1(SqlKind.IS_NULL, a, unknownAs);
+        if (simplified != null
+            && simplified.isAlwaysFalse()) {
+          final Sarg sarg2 = Sarg.of(false, sarg.rangeSet);
+          final RexLiteral literal2 =
+              rexBuilder.makeLiteral(sarg2, literal.getType(),
+                  literal.getTypeName());
+          // Now we've strengthened containsNull to false, try to simplify again
+          return simplifySearch(
+              call.clone(call.type, ImmutableList.of(a, literal2)),
+              unknownAs);
+        }
+      } else if (sarg.isPoints() && sarg.pointCount <= 1) {
+        // Expand "SEARCH(x, Sarg([point])" to "x = point"
+        // and "SEARCH(x, Sarg([])" to "false"
+        return RexUtil.expandSearch(rexBuilder, null, call);
+      }
+    }
+    return call;
+  }
+
   private RexNode simplifyCast(RexCall e) {
     RexNode operand = e.getOperands().get(0);
     operand = simplify(operand, UNKNOWN);
     if (sameTypeOrNarrowsNullability(e.getType(), operand.getType())) {
       return operand;
+    }
+    if (RexUtil.isLosslessCast(operand)) {
+      // x :: y below means cast(x as y) (which is PostgreSQL-specifiic cast by the way)
+      // A) Remove lossless casts:
+      // A.1) intExpr :: bigint :: int => intExpr
+      // A.2) char2Expr :: char(5) :: char(2) => char2Expr
+      // B) There are cases when we can't remove two casts, but we could probably remove inner one
+      // B.1) char2expression :: char(4) :: char(5) -> char2expression :: char(5)
+      // B.2) char2expression :: char(10) :: char(5) -> char2expression :: char(5)
+      // B.3) char2expression :: varchar(10) :: char(5) -> char2expression :: char(5)
+      // B.4) char6expression :: varchar(10) :: char(5) -> char6expression :: char(5)
+      // C) Simplification is not possible:
+      // C.1) char6expression :: char(3) :: char(5) -> must not be changed
+      //      the input is truncated to 3 chars, so we can't use char6expression :: char(5)
+      // C.2) varchar2Expr :: char(5) :: varchar(2) -> must not be changed
+      //      the input have to be padded with spaces (up to 2 chars)
+      // C.3) char2expression :: char(4) :: varchar(5) -> must not be changed
+      //      would not have the padding
+
+      // The approach seems to be:
+      // 1) Ensure inner cast is lossless (see if above)
+      // 2) If operand of the inner cast has the same type as the outer cast,
+      //    remove two casts except C.2 or C.3-like pattern (== inner cast is CHAR)
+      // 3) If outer cast is lossless, remove inner cast (B-like cases)
+
+      // Here we try to remove two casts in one go (A-like cases)
+      RexNode intExpr = ((RexCall) operand).operands.get(0);
+      // intExpr == CHAR detects A.1
+      // operand != CHAR detects C.2
+      if ((intExpr.getType().getSqlTypeName() == SqlTypeName.CHAR
+          || operand.getType().getSqlTypeName() != SqlTypeName.CHAR)
+          && sameTypeOrNarrowsNullability(e.getType(), intExpr.getType())) {
+        return intExpr;
+      }
+      // Here we try to remove inner cast (B-like cases)
+      if (RexUtil.isLosslessCast(intExpr.getType(), operand.getType())
+          && (e.getType().getSqlTypeName() == operand.getType().getSqlTypeName()
+          || e.getType().getSqlTypeName() == SqlTypeName.CHAR
+          || operand.getType().getSqlTypeName() != SqlTypeName.CHAR)
+          && SqlTypeCoercionRule.instance()
+          .canApplyFrom(intExpr.getType().getSqlTypeName(), e.getType().getSqlTypeName())) {
+        return rexBuilder.makeCast(e.getType(), intExpr);
+      }
     }
     switch (operand.getKind()) {
     case LITERAL:
@@ -1810,12 +2065,17 @@ public class RexSimplify {
         switch (e.getType().getSqlTypeName()) {
         case TIMESTAMP:
           return e;
+        default:
+          break;
         }
+        break;
+      default:
         break;
       }
       final List<RexNode> reducedValues = new ArrayList<>();
-      executor.reduce(rexBuilder, ImmutableList.of(e), reducedValues);
-      return Objects.requireNonNull(
+      final RexNode simplifiedExpr = rexBuilder.makeCast(e.getType(), operand);
+      executor.reduce(rexBuilder, ImmutableList.of(simplifiedExpr), reducedValues);
+      return requireNonNull(
           Iterables.getOnlyElement(reducedValues));
     default:
       if (operand == e.getOperands().get(0)) {
@@ -1893,9 +2153,11 @@ public class RexSimplify {
       case MILLISECOND:
       case MICROSECOND:
         if (inner == TimeUnit.QUARTER) {
-          return outer == TimeUnit.YEAR || outer == TimeUnit.QUARTER;
+          return outer == TimeUnit.YEAR;
         }
         return outer.ordinal() <= inner.ordinal();
+      default:
+        break;
       }
       break;
     case QUARTER:
@@ -1909,7 +2171,12 @@ public class RexSimplify {
       case MILLISECOND:
       case MICROSECOND:
         return true;
+      default:
+        break;
       }
+      break;
+    default:
+      break;
     }
     return false;
   }
@@ -1921,7 +2188,7 @@ public class RexSimplify {
     return RexUtil.removeNullabilityCast(rexBuilder.getTypeFactory(), e);
   }
 
-  private static <C extends Comparable<C>> RexNode processRange(
+  private static <C extends Comparable<C>> @Nullable RexNode processRange(
       RexBuilder rexBuilder, List<RexNode> terms,
       Map<RexNode, Pair<Range<C>, List<RexNode>>> rangeTerms, RexNode term,
       RexNode ref, C v0, SqlKind comparison) {
@@ -1929,7 +2196,7 @@ public class RexSimplify {
     if (p == null) {
       rangeTerms.put(ref,
           Pair.of(range(comparison, v0),
-              (List<RexNode>) ImmutableList.of(term)));
+              ImmutableList.of(term)));
     } else {
       // Exists
       boolean removeUpperBound = false;
@@ -1944,7 +2211,7 @@ public class RexSimplify {
         }
         rangeTerms.put(ref,
             Pair.of(Range.singleton(v0),
-                (List<RexNode>) ImmutableList.of(term)));
+                ImmutableList.of(term)));
         // remove
         for (RexNode e : p.right) {
           replaceLast(terms, e, trueLiteral);
@@ -2102,7 +2369,7 @@ public class RexSimplify {
         }
         newBounds.add(term);
         rangeTerms.put(ref,
-            Pair.of(r, (List<RexNode>) newBounds.build()));
+            Pair.of(r, newBounds.build()));
       } else if (removeLowerBound) {
         ImmutableList.Builder<RexNode> newBounds = ImmutableList.builder();
         for (RexNode e : p.right) {
@@ -2114,7 +2381,7 @@ public class RexSimplify {
         }
         newBounds.add(term);
         rangeTerms.put(ref,
-            Pair.of(r, (List<RexNode>) newBounds.build()));
+            Pair.of(r, newBounds.build()));
       }
     }
     // Default
@@ -2139,15 +2406,41 @@ public class RexSimplify {
     }
   }
 
+  @SuppressWarnings("BetaApi")
+  private static <C extends Comparable<C>> RangeSet<C> rangeSet(SqlKind comparison,
+      C c) {
+    switch (comparison) {
+    case EQUALS:
+    case LESS_THAN:
+    case LESS_THAN_OR_EQUAL:
+    case GREATER_THAN:
+    case GREATER_THAN_OR_EQUAL:
+      return ImmutableRangeSet.of(range(comparison, c));
+    case NOT_EQUALS:
+      return ImmutableRangeSet.<C>builder()
+          .add(range(SqlKind.LESS_THAN, c))
+          .add(range(SqlKind.GREATER_THAN, c))
+          .build();
+    default:
+      throw new AssertionError();
+    }
+  }
+
   /** Marker interface for predicates (expressions that evaluate to BOOLEAN). */
   private interface Predicate {
     /** Wraps an expression in a Predicate or returns null. */
-    static Predicate of(RexNode t) {
+    static @Nullable Predicate of(RexNode t) {
       final Predicate p = Comparison.of(t);
       if (p != null) {
         return p;
       }
       return IsPredicate.of(t);
+    }
+
+    /** Returns whether this predicate can be used while simplifying other OR
+     * operands. */
+    default boolean allowedInOr(RelOptPredicateList predicates) {
+      return true;
     }
   }
 
@@ -2161,19 +2454,20 @@ public class RexSimplify {
     final RexLiteral literal;
 
     private Comparison(RexNode ref, SqlKind kind, RexLiteral literal) {
-      this.ref = Objects.requireNonNull(ref);
-      this.kind = Objects.requireNonNull(kind);
-      this.literal = Objects.requireNonNull(literal);
+      this.ref = requireNonNull(ref);
+      this.kind = requireNonNull(kind);
+      this.literal = requireNonNull(literal);
     }
 
-    /** Creates a comparison, between a {@link RexInputRef} or {@link RexFieldAccess}
-     * and a literal. */
-    static Comparison of(RexNode e) {
-      return of(e, node -> RexUtil.isReferenceOrAccess(node, true));
+    /** Creates a comparison, between a {@link RexInputRef} or {@link RexFieldAccess} or
+     * deterministic {@link RexCall} and a literal. */
+    static @Nullable Comparison of(RexNode e) {
+      return of(e, node -> RexUtil.isReferenceOrAccess(node, true)
+          || RexUtil.isDeterministic(node));
     }
 
     /** Creates a comparison, or returns null. */
-    static Comparison of(RexNode e, java.util.function.Predicate<RexNode> nodePredicate) {
+    static @Nullable Comparison of(RexNode e, java.util.function.Predicate<RexNode> nodePredicate) {
       switch (e.getKind()) {
       case EQUALS:
       case NOT_EQUALS:
@@ -2189,15 +2483,29 @@ public class RexSimplify {
           if (nodePredicate.test(left)) {
             return new Comparison(left, e.getKind(), (RexLiteral) right);
           }
+          break;
+        default:
+          break;
         }
         switch (left.getKind()) {
         case LITERAL:
           if (nodePredicate.test(right)) {
             return new Comparison(right, e.getKind().reverse(), (RexLiteral) left);
           }
+          break;
+        default:
+          break;
         }
+        break;
+      default:
+        break;
       }
       return null;
+    }
+
+    @Override public boolean allowedInOr(RelOptPredicateList predicates) {
+      return !ref.getType().isNullable()
+          || predicates.isEffectivelyNotNull(ref);
     }
   }
 
@@ -2207,12 +2515,12 @@ public class RexSimplify {
     final SqlKind kind;
 
     private IsPredicate(RexNode ref, SqlKind kind) {
-      this.ref = Objects.requireNonNull(ref);
-      this.kind = Objects.requireNonNull(kind);
+      this.ref = requireNonNull(ref);
+      this.kind = requireNonNull(kind);
     }
 
     /** Creates an IS predicate, or returns null. */
-    static IsPredicate of(RexNode e) {
+    static @Nullable IsPredicate of(RexNode e) {
       switch (e.getKind()) {
       case IS_NULL:
       case IS_NOT_NULL:
@@ -2221,6 +2529,8 @@ public class RexSimplify {
           return null;
         }
         return new IsPredicate(pA, e.getKind());
+      default:
+        break;
       }
       return null;
     }
@@ -2274,7 +2584,7 @@ public class RexSimplify {
    * @param predicates Filter condition predicates
    * @return simplified conjunction of predicates for the filter, null if always false
    */
-  public RexNode simplifyFilterPredicates(Iterable<? extends RexNode> predicates) {
+  public @Nullable RexNode simplifyFilterPredicates(Iterable<? extends RexNode> predicates) {
     final RexNode simplifiedAnds =
         withPredicateElimination(Bug.CALCITE_2401_FIXED)
             .simplifyUnknownAsFalse(
@@ -2298,6 +2608,7 @@ public class RexSimplify {
    * <p>Returns whether the value was found.
    */
   private static <E> boolean replaceLast(List<E> list, E oldVal, E newVal) {
+    @SuppressWarnings("argument.type.incompatible")
     final int index = list.lastIndexOf(oldVal);
     if (index < 0) {
       return false;
@@ -2306,39 +2617,300 @@ public class RexSimplify {
     return true;
   }
 
-  private RexNode simplifyIf(RexCall e, RexUnknownAs unknownAs) {
-    List<RexNode> operands = e.getOperands();
-    List<RexNode> resultRexNode = new ArrayList<>();
+  /** Gathers expressions that can be converted into
+   * {@link Sarg search arguments}. */
+  static class SargCollector {
+    final Map<RexNode, RexSargBuilder> map = new HashMap<>();
+    private final RexBuilder rexBuilder;
+    private final boolean negate;
+    /**
+     * Count of the new terms after converting all the operands to
+     * {@code SEARCH} on a {@link Sarg}. It is used to decide whether
+     * the new terms are simpler.
+     */
+    private int newTermsCount;
 
-    for (RexNode operand : operands) {
-      resultRexNode.add(simplify(operand, unknownAs));
+    SargCollector(RexBuilder rexBuilder, boolean negate) {
+      this.rexBuilder = rexBuilder;
+      this.negate = negate;
     }
 
-    if (resultRexNode.get(0).isAlwaysTrue()) {
-      return resultRexNode.get(1);
-    } else if (resultRexNode.get(0).isAlwaysFalse()) {
-      return resultRexNode.get(2);
+    private void accept(RexNode term, List<RexNode> newTerms) {
+      if (!accept_(term, newTerms)) {
+        newTerms.add(term);
+      }
+      newTermsCount = newTerms.size();
     }
-    return e;
+
+    private boolean accept_(RexNode e, List<RexNode> newTerms) {
+      switch (e.getKind()) {
+      case LESS_THAN:
+      case LESS_THAN_OR_EQUAL:
+      case GREATER_THAN:
+      case GREATER_THAN_OR_EQUAL:
+      case EQUALS:
+      case NOT_EQUALS:
+      case SEARCH:
+        return accept2(((RexCall) e).operands.get(0),
+            ((RexCall) e).operands.get(1), e.getKind(), newTerms);
+      case IS_NULL:
+      case IS_NOT_NULL:
+        final RexNode arg = ((RexCall) e).operands.get(0);
+        return accept1(arg, e.getKind(),
+            rexBuilder.makeNullLiteral(arg.getType()), newTerms);
+      default:
+        return false;
+      }
+    }
+
+    private boolean accept2(RexNode left, RexNode right, SqlKind kind,
+        List<RexNode> newTerms) {
+      switch (left.getKind()) {
+      case INPUT_REF:
+      case FIELD_ACCESS:
+        switch (right.getKind()) {
+        case LITERAL:
+          return accept1(left, kind, (RexLiteral) right, newTerms);
+        default:
+          break;
+        }
+        return false;
+      case LITERAL:
+        switch (right.getKind()) {
+        case INPUT_REF:
+        case FIELD_ACCESS:
+          return accept1(right, kind.reverse(), (RexLiteral) left, newTerms);
+        default:
+          break;
+        }
+        return false;
+      default:
+        break;
+      }
+      return false;
+    }
+
+    private static <E> E addFluent(List<? super E> list, E e) {
+      list.add(e);
+      return e;
+    }
+
+    // always returns true
+    private boolean accept1(RexNode e, SqlKind kind,
+        @Nullable RexLiteral literal, List<RexNode> newTerms) {
+      final RexSargBuilder b =
+          map.computeIfAbsent(e, e2 ->
+              addFluent(newTerms, new RexSargBuilder(e2, rexBuilder, negate)));
+      if (negate) {
+        kind = kind.negateNullSafe2();
+      }
+      final Comparable value = requireNonNull(literal, "literal").getValueAs(Comparable.class);
+      switch (kind) {
+      case LESS_THAN:
+        b.addRange(Range.lessThan(requireNonNull(value, "value")), literal.getType());
+        return true;
+      case LESS_THAN_OR_EQUAL:
+        b.addRange(Range.atMost(requireNonNull(value, "value")), literal.getType());
+        return true;
+      case GREATER_THAN:
+        b.addRange(Range.greaterThan(requireNonNull(value, "value")), literal.getType());
+        return true;
+      case GREATER_THAN_OR_EQUAL:
+        b.addRange(Range.atLeast(requireNonNull(value, "value")), literal.getType());
+        return true;
+      case EQUALS:
+        b.addRange(Range.singleton(requireNonNull(value, "value")), literal.getType());
+        return true;
+      case NOT_EQUALS:
+        b.addRange(Range.lessThan(requireNonNull(value, "value")), literal.getType());
+        b.addRange(Range.greaterThan(requireNonNull(value, "value")), literal.getType());
+        return true;
+      case IS_NULL:
+        if (negate) {
+          ++b.notNullTermCount;
+        } else {
+          ++b.nullTermCount;
+        }
+        return true;
+      case IS_NOT_NULL:
+        if (negate) {
+          ++b.nullTermCount;
+        } else {
+          ++b.notNullTermCount;
+        }
+        b.addAll();
+        return true;
+      case SEARCH:
+        final Sarg sarg = literal.getValueAs(Sarg.class);
+        b.addSarg(requireNonNull(sarg, "sarg"), negate, literal.getType());
+        return true;
+      default:
+        throw new AssertionError("unexpected " + kind);
+      }
+    }
+
+    /**
+     * Returns whether the merged {@code sarg} with given {@code unknownAs} keeps the semantics,
+     * The merge can not go ahead if the semantics change.
+     *
+     * @return true if the semantics does not change
+     */
+    private static boolean canMerge(Sarg sarg, RexUnknownAs unknownAs) {
+      final boolean isAllOrNone = sarg.isAll() || sarg.isNone();
+      final boolean containsNull = sarg.containsNull;
+      switch (unknownAs) {
+      case UNKNOWN:
+        // "unknown as unknown" can not be simplified to
+        // "IS NULL"/"IS NOT NULL"/"TRUE"/"FALSE"
+        return !isAllOrNone;
+      case TRUE:
+        // "unknown as true" can not be simplified to
+        // "false" or "IS NOT NULL"
+        return containsNull || !isAllOrNone;
+      case FALSE:
+        // "unknown as false" can not be simplified to
+        // "true" or "IS NULL"
+        return !containsNull || !isAllOrNone;
+      default:
+        return true;
+      }
+    }
+
+    /** Returns whether it is worth to fix and convert to {@code SEARCH} calls. */
+    boolean needToFix(RexUnknownAs unknownAs) {
+      // Fix and converts to SEARCH if:
+      // 1. A Sarg has complexity greater than 1;
+      // 2. The terms are reduced as simpler Sarg points;
+      // 3. The terms are reduced as simpler Sarg comparison.
+
+      // Ignore 'negate' just to be compatible with previous versions of this
+      // method. "build().complexity()" would be a better estimate, if we could
+      // switch to it breaking lots of plans.
+      final Collection<RexSargBuilder> builders = map.values();
+      if (builders.stream().anyMatch(b -> b.build(false).complexity() > 1)) {
+        return true;
+      }
+      if (builders.size() == 1
+          && !canMerge(builders.iterator().next().build(), unknownAs)) {
+        return false;
+      }
+      return newTermsCount == 1
+          && map.values().stream().allMatch(b -> simpleSarg(b.build()));
+    }
+
+    /**
+     * Returns whether this Sarg can be expanded to more simple form, e.g.
+     * the IN call or single comparison.
+     */
+    private static boolean simpleSarg(Sarg sarg) {
+      return sarg.isPoints() || RangeSets.isOpenInterval(sarg.rangeSet);
+    }
+
+    /** If a term is a call to {@code SEARCH} on a {@link RexSargBuilder},
+     * converts it to a {@code SEARCH} on a {@link Sarg}. */
+    static RexNode fix(RexBuilder rexBuilder, RexNode term) {
+      if (term instanceof RexSargBuilder) {
+        final RexSargBuilder sargBuilder = (RexSargBuilder) term;
+        final Sarg sarg = sargBuilder.build();
+        if (sarg.complexity() <= 1 && simpleSarg(sarg)) {
+          // Expand small sargs into comparisons in order to avoid plan changes
+          // and better readability.
+          return RexUtil.sargRef(rexBuilder, sargBuilder.ref, sarg, term.getType());
+        }
+        return rexBuilder.makeCall(SqlStdOperatorTable.SEARCH, sargBuilder.ref,
+            rexBuilder.makeSearchArgumentLiteral(sarg, term.getType()));
+      }
+      return term;
+    }
   }
 
-  /***
-   * Simplifying NVL function, If first operand is not null then return
-   * first operand else return second operand.
-   * And return whole NVL function if first operand is not simplifiable.
-   * @param e RexCall
-   * @return RexNode
-   */
-  private RexNode simplifyNvl(RexCall e) {
-    final List<RexNode> operands = new ArrayList<>(e.operands);
-    simplifyList(operands, UNKNOWN);
+  /** Equivalent to a {@link RexLiteral} whose value is a {@link Sarg},
+   * but mutable, so that the Sarg can be expanded as {@link SargCollector}
+   * traverses a list of OR or AND terms.
+   *
+   * <p>The {@link SargCollector#fix} method converts it to an immutable
+   * literal. */
+  @SuppressWarnings("BetaApi")
+  private static class RexSargBuilder extends RexNode {
+    final RexNode ref;
+    final RexBuilder rexBuilder;
+    final boolean negate;
+    final List<RelDataType> types = new ArrayList<>();
+    final RangeSet<Comparable> rangeSet = TreeRangeSet.create();
+    int notNullTermCount;
+    int nullTermCount;
 
-    RexNode rexNode = simplifyIsNotNull(operands.get(0));
-    if (rexNode != null && rexNode.isAlwaysTrue()) {
-      return operands.get(0);
-    } else if (rexNode != null && rexNode.isAlwaysFalse()) {
-      return operands.get(1);
+    RexSargBuilder(RexNode ref, RexBuilder rexBuilder, boolean negate) {
+      this.ref = requireNonNull(ref);
+      this.rexBuilder = requireNonNull(rexBuilder);
+      this.negate = negate;
     }
-    return rexBuilder.makeCall(e.getType(), e.getOperator(), operands);
+
+    @Override public String toString() {
+      return "SEARCH(" + ref + ", " + (negate ? "NOT " : "") + rangeSet
+          + ", " + (nullTermCount + notNullTermCount)
+          + " terms of which " + nullTermCount + " allow null)";
+    }
+
+    <C extends Comparable<C>> Sarg<C> build() {
+      return build(negate);
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked", "UnstableApiUsage"})
+    <C extends Comparable<C>> Sarg<C> build(boolean negate) {
+      if (negate) {
+        return Sarg.of(notNullTermCount == 0,
+            (RangeSet) rangeSet.complement());
+      } else {
+        return Sarg.of(nullTermCount > 0, (RangeSet) rangeSet);
+      }
+    }
+
+    @Override public RelDataType getType() {
+      if (this.types.isEmpty()) {
+        // Expression is "x IS NULL"
+        return ref.getType();
+      }
+      final List<RelDataType> distinctTypes = Util.distinctList(this.types);
+      return requireNonNull(
+          rexBuilder.typeFactory.leastRestrictive(distinctTypes),
+          () -> "Can't find leastRestrictive type among " + distinctTypes);
+    }
+
+    @Override public <R> R accept(RexVisitor<R> visitor) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override public <R, P> R accept(RexBiVisitor<R, P> visitor, P arg) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override public boolean equals(@Nullable Object obj) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override public int hashCode() {
+      throw new UnsupportedOperationException();
+    }
+
+    void addAll() {
+      rangeSet.add(Range.all());
+    }
+
+    void addRange(Range<Comparable> range, RelDataType type) {
+      types.add(type);
+      rangeSet.add(range);
+      ++notNullTermCount;
+    }
+
+    void addSarg(Sarg sarg, boolean negate, RelDataType type) {
+      types.add(type);
+      rangeSet.addAll(negate ? sarg.rangeSet.complement() : sarg.rangeSet);
+      if (sarg.containsNull) {
+        ++nullTermCount;
+      } else {
+        ++notNullTermCount;
+      }
+    }
   }
 }

--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -613,6 +613,18 @@ public class SqlFunctions {
     return Pattern.matches(regex, s);
   }
 
+  /** SQL {@code ILIKE} function. */
+  public static boolean ilike(String s, String pattern) {
+    final String regex = Like.sqlToRegexLike(pattern, null);
+    return Pattern.compile(regex, Pattern.CASE_INSENSITIVE).matcher(s).matches();
+  }
+
+  /** SQL {@code ILIKE} function with escape. */
+  public static boolean ilike(String s, String pattern, String escape) {
+    final String regex = Like.sqlToRegexLike(pattern, escape);
+    return Pattern.compile(regex, Pattern.CASE_INSENSITIVE).matcher(s).matches();
+  }
+
   /** SQL {@code SIMILAR} function. */
   public static boolean similar(String s, String pattern) {
     final String regex = Like.sqlToRegexSimilar(pattern, null);

--- a/core/src/main/java/org/apache/calcite/sql/SqlKind.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlKind.java
@@ -1449,6 +1449,14 @@ public enum SqlKind {
       return GREATER_THAN;
     case GREATER_THAN_OR_EQUAL:
       return LESS_THAN;
+    case IN:
+      return NOT_IN;
+    case NOT_IN:
+      return IN;
+    case DRUID_IN:
+      return DRUID_NOT_IN;
+    case DRUID_NOT_IN:
+      return DRUID_IN;
     case IS_TRUE:
       return IS_FALSE;
     case IS_FALSE:

--- a/core/src/main/java/org/apache/calcite/sql/SqlOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlOperator.java
@@ -595,6 +595,10 @@ public abstract class SqlOperator {
             argTypes, null, null, getSyntax(), getKind(),
             validator.getCatalogReader().nameMatcher(), false);
 
+    if (sqlOperator == null) {
+      throw validator.handleUnresolvedFunction(call, this, argTypes, null);
+    }
+
     ((SqlBasicCall) call).setOperator(castNonNull(sqlOperator));
     RelDataType type = call.getOperator().validateOperands(validator, scope, call);
 
@@ -953,6 +957,17 @@ public abstract class SqlOperator {
    * return type inference is implemented by a subclass override. */
   public @Nullable SqlReturnTypeInference getReturnTypeInference() {
     return returnTypeInference;
+  }
+
+  /** Returns the operator that is the logical inverse of this operator.
+   *
+   * <p>For example, {@code SqlStdOperatorTable.LIKE.not()} returns
+   * {@code SqlStdOperatorTable.NOT_LIKE}, and vice versa.
+   *
+   * <p>By default, returns {@code null}, which means there is no inverse
+   * operator. */
+  public @Nullable SqlOperator not() {
+    return null;
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/sql/SqlSpecialOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlSpecialOperator.java
@@ -99,8 +99,8 @@ public class SqlSpecialOperator extends SqlOperator {
     SqlOperator op(int i);
     SqlParserPos pos(int i);
     boolean isOp(int i);
-    @Nullable SqlNode node(int i);
-    void replaceSublist(int start, int end, @Nullable SqlNode e);
+    SqlNode node(int i);
+    void replaceSublist(int start, int end, SqlNode e);
 
     /** Creates a parser whose token sequence is a copy of a subset of this
      * token sequence. */

--- a/core/src/main/java/org/apache/calcite/sql/dialect/PostgresqlSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/PostgresqlSqlDialect.java
@@ -27,12 +27,15 @@ import org.apache.calcite.sql.SqlDataTypeSpec;
 import org.apache.calcite.sql.SqlDialect;
 import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.fun.SqlFloorFunction;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.SqlTypeName;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.List;
 
 /**
  * A <code>SqlDialect</code> implementation for the PostgreSQL database.
@@ -92,6 +95,17 @@ public class PostgresqlSqlDialect extends SqlDialect {
     return new SqlDataTypeSpec(
         new SqlAlienSystemTypeNameSpec(castSpec, type.getSqlTypeName(), SqlParserPos.ZERO),
         SqlParserPos.ZERO);
+  }
+
+  @Override public boolean supportsFunction(SqlOperator operator,
+      RelDataType type, final List<RelDataType> paramTypes) {
+    switch (operator.kind) {
+    case LIKE:
+      // introduces support for ILIKE as well
+      return true;
+    default:
+      return super.supportsFunction(operator, type, paramTypes);
+    }
   }
 
   @Override public boolean requiresAliasForFromItems() {

--- a/core/src/main/java/org/apache/calcite/sql/dialect/VerticaSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/VerticaSqlDialect.java
@@ -17,7 +17,11 @@
 package org.apache.calcite.sql.dialect;
 
 import org.apache.calcite.avatica.util.Casing;
+import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.SqlDialect;
+import org.apache.calcite.sql.SqlOperator;
+
+import java.util.List;
 
 /**
  * A <code>SqlDialect</code> implementation for the Vertica database.
@@ -37,5 +41,16 @@ public class VerticaSqlDialect extends SqlDialect {
 
   @Override public boolean supportsNestedAggregations() {
     return false;
+  }
+
+  @Override public boolean supportsFunction(SqlOperator operator,
+      RelDataType type, final List<RelDataType> paramTypes) {
+    switch (operator.kind) {
+    case LIKE:
+      // introduces support for ILIKE as well
+      return true;
+    default:
+      return super.supportsFunction(operator, type, paramTypes);
+    }
   }
 }

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlBetweenOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlBetweenOperator.java
@@ -117,8 +117,29 @@ public class SqlBetweenOperator extends SqlInfixOperator {
     return litmus.fail("not a rex operator");
   }
 
+  /**
+   * Returns whether this is 'NOT' variant of an operator.
+   *
+   * @see #not()
+   */
   public boolean isNegated() {
     return negated;
+  }
+
+  @Override public SqlOperator not() {
+    return of(negated, flag == Flag.SYMMETRIC);
+  }
+
+  private static SqlBetweenOperator of(boolean negated, boolean symmetric) {
+    if (symmetric) {
+      return negated
+          ? SqlStdOperatorTable.SYMMETRIC_BETWEEN
+          : SqlStdOperatorTable.SYMMETRIC_NOT_BETWEEN;
+    } else {
+      return negated
+          ? SqlStdOperatorTable.NOT_BETWEEN
+          : SqlStdOperatorTable.BETWEEN;
+    }
   }
 
   @Override public RelDataType inferReturnType(

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlInOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlInOperator.java
@@ -26,6 +26,7 @@ import org.apache.calcite.sql.SqlCallBinding;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.type.ComparableOperandTypeChecker;
 import org.apache.calcite.sql.type.InferTypes;
 import org.apache.calcite.sql.type.OperandTypes;
@@ -78,6 +79,25 @@ public class SqlInOperator extends SqlBinaryOperator {
   @Deprecated // to be removed before 2.0
   public boolean isNotIn() {
     return kind == SqlKind.NOT_IN;
+  }
+
+  @Override public SqlOperator not() {
+    return of(kind.negateNullSafe());
+  }
+
+  private static SqlBinaryOperator of(SqlKind kind) {
+    switch (kind) {
+    case IN:
+      return SqlStdOperatorTable.IN;
+    case NOT_IN:
+      return SqlStdOperatorTable.NOT_IN;
+    case DRUID_IN:
+      return SqlInternalOperators.DRUID_IN;
+    case DRUID_NOT_IN:
+      return SqlInternalOperators.DRUID_NOT_IN;
+    default:
+      throw new AssertionError("unexpected " + kind);
+    }
   }
 
   @Override public boolean validRexOperands(int count, Litmus litmus) {

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -27,6 +27,7 @@ import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlOperatorBinding;
 import org.apache.calcite.sql.SqlOperatorTable;
+import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlSyntax;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.type.InferTypes;
@@ -710,6 +711,16 @@ public abstract class SqlLibraryOperators {
           null,
           OperandTypes.STRING_STRING,
           SqlFunctionCategory.STRING);
+
+  /** The case-insensitive variant of the LIKE operator. */
+  @LibraryOperator(libraries = {POSTGRESQL})
+  public static final SqlSpecialOperator ILIKE =
+      new SqlLikeOperator("ILIKE", SqlKind.LIKE, false, false);
+
+  /** The case-insensitive variant of the NOT LIKE operator. */
+  @LibraryOperator(libraries = {POSTGRESQL})
+  public static final SqlSpecialOperator NOT_ILIKE =
+      new SqlLikeOperator("NOT ILIKE", SqlKind.LIKE, true, false);
 
   /** The "CONCAT(arg, ...)" function that concatenates strings.
    * For example, "CONCAT('a', 'bc', 'd')" returns "abcd". */

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlPosixRegexOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlPosixRegexOperator.java
@@ -22,6 +22,7 @@ import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlCallBinding;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlOperandCountRange;
+import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.type.InferTypes;
 import org.apache.calcite.sql.type.OperandTypes;
@@ -78,6 +79,22 @@ public class SqlPosixRegexOperator extends SqlBinaryOperator {
 
   // ~ Methods ----------------------------------------------------------------
 
+  @Override public SqlOperator not() {
+    return of(!negated, caseSensitive);
+  }
+
+  private static SqlOperator of(boolean negated, boolean ignoreCase) {
+    if (ignoreCase) {
+      return negated
+          ? SqlStdOperatorTable.NEGATED_POSIX_REGEX_CASE_SENSITIVE
+          : SqlStdOperatorTable.POSIX_REGEX_CASE_SENSITIVE;
+    } else {
+      return negated
+          ? SqlStdOperatorTable.NEGATED_POSIX_REGEX_CASE_INSENSITIVE
+          : SqlStdOperatorTable.POSIX_REGEX_CASE_INSENSITIVE;
+    }
+  }
+
   @Override public SqlOperandCountRange getOperandCountRange() {
     return SqlOperandCountRanges.of(2);
   }
@@ -120,10 +137,20 @@ public class SqlPosixRegexOperator extends SqlBinaryOperator {
     writer.endList(frame);
   }
 
+  /**
+   * Returns whether this operator matches the case of its operands.
+   *
+   * @return whether this operator matches the case of its operands
+   */
   public boolean isCaseSensitive() {
     return caseSensitive;
   }
 
+  /**
+   * Returns whether this is 'NOT' variant of an operator.
+   *
+   * @see #not()
+   */
   public boolean isNegated() {
     return negated;
   }

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
@@ -1405,22 +1405,24 @@ public class SqlStdOperatorTable extends ReflectiveSqlOperatorTable {
           true);
 
   public static final SqlSpecialOperator NOT_LIKE =
-      new SqlLikeOperator("NOT LIKE", SqlKind.LIKE, true);
+      new SqlLikeOperator("NOT LIKE", SqlKind.LIKE, true, true);
 
   public static final SqlSpecialOperator LIKE =
-      new SqlLikeOperator("LIKE", SqlKind.LIKE, false);
+      new SqlLikeOperator("LIKE", SqlKind.LIKE, false, true);
 
   public static final SqlSpecialOperator NOT_SIMILAR_TO =
-      new SqlLikeOperator("NOT SIMILAR TO", SqlKind.SIMILAR, true);
+      new SqlLikeOperator("NOT SIMILAR TO", SqlKind.SIMILAR, true, true);
 
   public static final SqlSpecialOperator SIMILAR_TO =
-      new SqlLikeOperator("SIMILAR TO", SqlKind.SIMILAR, false);
+      new SqlLikeOperator("SIMILAR TO", SqlKind.SIMILAR, false, true);
 
-  public static final SqlBinaryOperator POSIX_REGEX_CASE_SENSITIVE = new SqlPosixRegexOperator(
-      "POSIX REGEX CASE SENSITIVE", SqlKind.POSIX_REGEX_CASE_SENSITIVE, true, false);
+  public static final SqlBinaryOperator POSIX_REGEX_CASE_SENSITIVE =
+      new SqlPosixRegexOperator("POSIX REGEX CASE SENSITIVE",
+          SqlKind.POSIX_REGEX_CASE_SENSITIVE, true, false);
 
-  public static final SqlBinaryOperator POSIX_REGEX_CASE_INSENSITIVE = new SqlPosixRegexOperator(
-      "POSIX REGEX CASE INSENSITIVE", SqlKind.POSIX_REGEX_CASE_INSENSITIVE, false, false);
+  public static final SqlBinaryOperator POSIX_REGEX_CASE_INSENSITIVE =
+      new SqlPosixRegexOperator("POSIX REGEX CASE INSENSITIVE",
+          SqlKind.POSIX_REGEX_CASE_INSENSITIVE, false, false);
 
   public static final SqlBinaryOperator NEGATED_POSIX_REGEX_CASE_SENSITIVE =
       new SqlPosixRegexOperator("NEGATED POSIX REGEX CASE SENSITIVE",
@@ -2656,6 +2658,24 @@ public class SqlStdOperatorTable extends ReflectiveSqlOperatorTable {
       return GREATER_THAN_OR_EQUAL;
     default:
       return operator;
+    }
+  }
+
+  /** Returns the operator for {@code LIKE} with given case-sensitivity,
+   * optionally negated. */
+  public static SqlOperator like(boolean negated, boolean caseSensitive) {
+    if (negated) {
+      if (caseSensitive) {
+        return NOT_LIKE;
+      } else {
+        return SqlLibraryOperators.NOT_ILIKE;
+      }
+    } else {
+      if (caseSensitive) {
+        return LIKE;
+      } else {
+        return SqlLibraryOperators.ILIKE;
+      }
     }
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/parser/SqlParserUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/parser/SqlParserUtil.java
@@ -687,7 +687,7 @@ public final class SqlParserUtil {
    *                    we encounter a token of this kind.
    * @return the root node of the tree which the list condenses into
    */
-  public static @Nullable SqlNode toTreeEx(SqlSpecialOperator.TokenSequence list,
+  public static SqlNode toTreeEx(SqlSpecialOperator.TokenSequence list,
       int start, final int minPrec, final SqlKind stopperKind) {
     PrecedenceClimbingParser parser = list.parser(start,
         token -> {
@@ -710,10 +710,10 @@ public final class SqlParserUtil {
     return node;
   }
 
-  private static @Nullable SqlNode convert(PrecedenceClimbingParser.Token token) {
+  private static SqlNode convert(PrecedenceClimbingParser.Token token) {
     switch (token.type) {
     case ATOM:
-      return (SqlNode) token.o;
+      return requireNonNull((SqlNode) token.o);
     case CALL:
       final PrecedenceClimbingParser.Call call =
           (PrecedenceClimbingParser.Call) token;
@@ -899,11 +899,11 @@ public final class SqlParserUtil {
       return list.get(i).o instanceof ToTreeListItem;
     }
 
-    @Override public @Nullable SqlNode node(int i) {
+    @Override public SqlNode node(int i) {
       return convert(list.get(i));
     }
 
-    @Override public void replaceSublist(int start, int end, @Nullable SqlNode e) {
+    @Override public void replaceSublist(int start, int end, SqlNode e) {
       SqlParserUtil.replaceSublist(list, start, end, parser.atom(e));
     }
   }
@@ -952,7 +952,7 @@ public final class SqlParserUtil {
             throw new AssertionError();
           }
         } else {
-          builder.atom(o);
+          builder.atom(requireNonNull(o));
         }
       }
       return builder.build();
@@ -980,11 +980,11 @@ public final class SqlParserUtil {
       return list.get(i) instanceof ToTreeListItem;
     }
 
-    @Override public @Nullable SqlNode node(int i) {
-      return (@Nullable SqlNode) list.get(i);
+    @Override public SqlNode node(int i) {
+      return requireNonNull((SqlNode) list.get(i));
     }
 
-    @Override public void replaceSublist(int start, int end, @Nullable SqlNode e) {
+    @Override public void replaceSublist(int start, int end, SqlNode e) {
       SqlParserUtil.replaceSublist(list, start, end, e);
     }
   }

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidator.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidator.java
@@ -36,6 +36,7 @@ import org.apache.calcite.sql.SqlMatchRecognize;
 import org.apache.calcite.sql.SqlMerge;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlOperatorTable;
 import org.apache.calcite.sql.SqlSelect;
 import org.apache.calcite.sql.SqlUpdate;
@@ -655,7 +656,7 @@ public interface SqlValidator {
       List<RelDataType> argTypes);
 
   /**
-   * Handles a call to a function which cannot be resolved. Returns a an
+   * Handles a call to a function which cannot be resolved. Returns an
    * appropriately descriptive error, which caller must throw.
    *
    * @param call               Call
@@ -665,7 +666,7 @@ public interface SqlValidator {
    * @param argNames           Names of arguments, or null if call by position
    */
   CalciteException handleUnresolvedFunction(SqlCall call,
-      SqlFunction unresolvedFunction, List<RelDataType> argTypes,
+      SqlOperator unresolvedFunction, List<RelDataType> argTypes,
       @Nullable List<String> argNames);
 
   /**

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -1921,7 +1921,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
   }
 
   @Override public CalciteException handleUnresolvedFunction(SqlCall call,
-      SqlFunction unresolvedFunction, List<RelDataType> argTypes,
+      SqlOperator unresolvedFunction, List<RelDataType> argTypes,
       @Nullable List<String> argNames) {
     // For builtins, we can give a better error message
     final List<SqlOperator> overloads = new ArrayList<>();
@@ -1939,12 +1939,16 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
       }
     }
 
-    AssignableOperandTypeChecker typeChecking =
-        new AssignableOperandTypeChecker(argTypes, argNames);
-    String signature =
-        typeChecking.getAllowedSignatures(
-            unresolvedFunction,
-            unresolvedFunction.getName());
+    final String signature;
+    if (unresolvedFunction instanceof SqlFunction) {
+      final SqlOperandTypeChecker typeChecking =
+          new AssignableOperandTypeChecker(argTypes, argNames);
+      signature =
+          typeChecking.getAllowedSignatures(unresolvedFunction,
+              unresolvedFunction.getName());
+    } else {
+      signature = unresolvedFunction.getName();
+    }
     throw newValidationError(call,
         RESOURCE.validatorUnknownFunction(signature));
   }

--- a/core/src/main/java/org/apache/calcite/sql2rel/StandardConvertletTable.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/StandardConvertletTable.java
@@ -172,6 +172,13 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
                 SqlStdOperatorTable.LIKE.createCall(SqlParserPos.ZERO,
                     call.getOperandList()))));
 
+    // Expand "x NOT ILIKE y" into "NOT (x ILIKE y)"
+    registerOp(SqlLibraryOperators.NOT_ILIKE,
+        (cx, call) -> cx.convertExpression(
+            SqlStdOperatorTable.NOT.createCall(SqlParserPos.ZERO,
+                SqlLibraryOperators.ILIKE.createCall(SqlParserPos.ZERO,
+                    call.getOperandList()))));
+
     // Expand "x NOT SIMILAR y" into "NOT (x SIMILAR y)"
     registerOp(SqlStdOperatorTable.NOT_SIMILAR_TO,
         (cx, call) -> cx.convertExpression(

--- a/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
+++ b/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
@@ -657,13 +657,11 @@ public class RelBuilder {
   private RexCall call(SqlOperator operator, List<RexNode> operandList) {
     switch (operator.getKind()) {
     case LIKE:
-      if (((SqlLikeOperator) operator).isNegated()) {
-        return (RexCall) not(call(SqlStdOperatorTable.LIKE, operandList));
-      }
-      break;
     case SIMILAR:
-      if (((SqlLikeOperator) operator).isNegated()) {
-        return (RexCall) not(call(SqlStdOperatorTable.SIMILAR_TO, operandList));
+      final SqlLikeOperator likeOperator = (SqlLikeOperator) operator;
+      if (likeOperator.isNegated()) {
+        final SqlOperator notLikeOperator = likeOperator.not();
+        return (RexCall) not(call(notLikeOperator, operandList));
       }
       break;
     default:

--- a/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
+++ b/core/src/main/java/org/apache/calcite/util/BuiltInMethod.java
@@ -450,6 +450,7 @@ public enum BuiltInMethod {
   LTRIM(SqlFunctions.class, "ltrim", String.class),
   RTRIM(SqlFunctions.class, "rtrim", String.class),
   LIKE(SqlFunctions.class, "like", String.class, String.class),
+  ILIKE(SqlFunctions.class, "ilike", String.class, String.class),
   SIMILAR(SqlFunctions.class, "similar", String.class, String.class),
   POSIX_REGEX(SqlFunctions.class, "posixRegex", String.class, String.class, boolean.class),
   REGEXP_REPLACE3(SqlFunctions.class, "regexpReplace", String.class,

--- a/core/src/main/java/org/apache/calcite/util/PrecedenceClimbingParser.java
+++ b/core/src/main/java/org/apache/calcite/util/PrecedenceClimbingParser.java
@@ -55,7 +55,7 @@ public class PrecedenceClimbingParser {
     last = p;
   }
 
-  public Token atom(@Nullable Object o) {
+  public Token atom(Object o) {
     return new Token(Type.ATOM, o, -1, -1);
   }
 
@@ -384,7 +384,7 @@ public class PrecedenceClimbingParser {
       return this;
     }
 
-    public Builder atom(@Nullable Object o) {
+    public Builder atom(Object o) {
       return add(dummy.atom(o));
     }
 

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterStructsTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterStructsTest.java
@@ -164,7 +164,7 @@ class RelToSqlConverterStructsTest {
 
   private RelToSqlConverterTest.Sql sql(String sql) {
     return new RelToSqlConverterTest.Sql(ROOT_SCHEMA, sql,
-        CalciteSqlDialect.DEFAULT, SqlParser.Config.DEFAULT,
+        CalciteSqlDialect.DEFAULT, SqlParser.Config.DEFAULT, ImmutableSet.of(),
         UnaryOperator.identity(), null, ImmutableList.of());
   }
 

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -167,6 +167,22 @@ class RelToSqlConverterTest {
         UnaryOperator.identity(), null, ImmutableList.of());
   }
 
+  private Sql sqlTest(String sql) {
+    return new Sql(CalciteAssert.SchemaSpec.FOODMART_TEST, sql,
+        CalciteSqlDialect.DEFAULT, SqlParser.Config.DEFAULT, ImmutableSet.of(),
+        UnaryOperator.identity(), null, ImmutableList.of());
+  }
+
+  public static Frameworks.ConfigBuilder salesConfig() {
+    final SchemaPlus rootSchema = Frameworks.createRootSchema(true);
+    return Frameworks.newConfigBuilder()
+        .parserConfig(SqlParser.Config.DEFAULT)
+        .defaultSchema(
+            CalciteAssert.addSchema(rootSchema, CalciteAssert.SchemaSpec.SALESSCHEMA))
+        .traitDefs((List<RelTraitDef>) null)
+        .programs(Programs.ofRules(Programs.RULE_SET));
+  }
+
   /** Initiates a test case with a given {@link RelNode} supplier. */
   private Sql relFn(Function<RelBuilder, RelNode> relFn) {
     return sql("?").relFn(relFn);

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -71,6 +71,8 @@ import org.apache.calcite.sql.dialect.MssqlSqlDialect;
 import org.apache.calcite.sql.dialect.MysqlSqlDialect;
 import org.apache.calcite.sql.dialect.OracleSqlDialect;
 import org.apache.calcite.sql.dialect.PostgresqlSqlDialect;
+import org.apache.calcite.sql.fun.SqlLibrary;
+import org.apache.calcite.sql.fun.SqlLibraryOperatorTableFactory;
 import org.apache.calcite.sql.dialect.SparkSqlDialect;
 import org.apache.calcite.sql.fun.SqlLibraryOperators;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
@@ -82,6 +84,7 @@ import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.sql.type.SqlTypeFactoryImpl;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.sql.util.SqlOperatorTables;
 import org.apache.calcite.sql.util.SqlShuttle;
 import org.apache.calcite.sql.validate.SqlConformance;
 import org.apache.calcite.sql2rel.SqlToRelConverter;
@@ -109,6 +112,7 @@ import com.google.common.collect.ImmutableSet;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collection;
 import java.math.BigDecimal;
 import java.time.DayOfWeek;
 import java.util.ArrayList;
@@ -116,6 +120,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
@@ -158,24 +163,8 @@ class RelToSqlConverterTest {
   /** Initiates a test case with a given SQL query. */
   private Sql sql(String sql) {
     return new Sql(CalciteAssert.SchemaSpec.JDBC_FOODMART, sql,
-        CalciteSqlDialect.DEFAULT, SqlParser.Config.DEFAULT,
+        CalciteSqlDialect.DEFAULT, SqlParser.Config.DEFAULT, ImmutableSet.of(),
         UnaryOperator.identity(), null, ImmutableList.of());
-  }
-
-  private Sql sqlTest(String sql) {
-    return new Sql(CalciteAssert.SchemaSpec.FOODMART_TEST, sql,
-        CalciteSqlDialect.DEFAULT, SqlParser.Config.DEFAULT,
-        UnaryOperator.identity(), null, ImmutableList.of());
-  }
-
-  public static Frameworks.ConfigBuilder salesConfig() {
-    final SchemaPlus rootSchema = Frameworks.createRootSchema(true);
-    return Frameworks.newConfigBuilder()
-        .parserConfig(SqlParser.Config.DEFAULT)
-        .defaultSchema(
-            CalciteAssert.addSchema(rootSchema, CalciteAssert.SchemaSpec.SALESSCHEMA))
-        .traitDefs((List<RelTraitDef>) null)
-        .programs(Programs.ofRules(Programs.RULE_SET));
   }
 
   /** Initiates a test case with a given {@link RelNode} supplier. */
@@ -185,9 +174,13 @@ class RelToSqlConverterTest {
 
   private static Planner getPlanner(List<RelTraitDef> traitDefs,
       SqlParser.Config parserConfig, SchemaPlus schema,
-      SqlToRelConverter.Config sqlToRelConf, Program... programs) {
+      SqlToRelConverter.Config sqlToRelConf, Collection<SqlLibrary> librarySet,
+      Program... programs) {
     final MockSqlOperatorTable operatorTable =
-            new MockSqlOperatorTable(SqlStdOperatorTable.instance());
+        new MockSqlOperatorTable(
+            SqlOperatorTables.chain(SqlStdOperatorTable.instance(),
+                SqlLibraryOperatorTableFactory.INSTANCE
+                    .getOperatorTable(librarySet)));
     MockSqlOperatorTable.addRamp(operatorTable);
     final FrameworkConfig config = Frameworks.newConfigBuilder()
         .parserConfig(parserConfig)
@@ -4618,6 +4611,24 @@ class RelToSqlConverterTest {
     sql(query).ok(expected);
   }
 
+  @Test void testIlike() {
+    String query = "select \"product_name\" from \"product\" a "
+        + "where \"product_name\" ilike 'abC'";
+    String expected = "SELECT \"product_name\"\n"
+        + "FROM \"foodmart\".\"product\"\n"
+        + "WHERE \"product_name\" ILIKE 'abC'";
+    sql(query).withLibrary(SqlLibrary.POSTGRESQL).ok(expected);
+  }
+
+  @Test void testNotIlike() {
+    String query = "select \"product_name\" from \"product\" a "
+        + "where \"product_name\" not ilike 'abC'";
+    String expected = "SELECT \"product_name\"\n"
+        + "FROM \"foodmart\".\"product\"\n"
+        + "WHERE \"product_name\" NOT ILIKE 'abC'";
+    sql(query).withLibrary(SqlLibrary.POSTGRESQL).ok(expected);
+  }
+
   @Test void testMatchRecognizePatternExpression() {
     String sql = "select *\n"
         + "  from \"product\" match_recognize\n"
@@ -8891,13 +8902,14 @@ class RelToSqlConverterTest {
     private final SchemaPlus schema;
     private final String sql;
     private final SqlDialect dialect;
+    private final Set<SqlLibrary> librarySet;
     private final Function<RelBuilder, RelNode> relFn;
     private final List<Function<RelNode, RelNode>> transforms;
     private final SqlParser.Config parserConfig;
     private final UnaryOperator<SqlToRelConverter.Config> config;
 
     Sql(CalciteAssert.SchemaSpec schemaSpec, String sql, SqlDialect dialect,
-        SqlParser.Config parserConfig,
+        SqlParser.Config parserConfig, Set<SqlLibrary> librarySet,
         UnaryOperator<SqlToRelConverter.Config> config,
         Function<RelBuilder, RelNode> relFn,
         List<Function<RelNode, RelNode>> transforms) {
@@ -8905,6 +8917,7 @@ class RelToSqlConverterTest {
       this.schema = CalciteAssert.addSchema(rootSchema, schemaSpec);
       this.sql = sql;
       this.dialect = dialect;
+      this.librarySet = librarySet;
       this.relFn = relFn;
       this.transforms = ImmutableList.copyOf(transforms);
       this.parserConfig = parserConfig;
@@ -8912,13 +8925,14 @@ class RelToSqlConverterTest {
     }
 
     Sql(SchemaPlus schema, String sql, SqlDialect dialect,
-        SqlParser.Config parserConfig,
+        SqlParser.Config parserConfig, Set<SqlLibrary> librarySet,
         UnaryOperator<SqlToRelConverter.Config> config,
         Function<RelBuilder, RelNode> relFn,
         List<Function<RelNode, RelNode>> transforms) {
       this.schema = schema;
       this.sql = sql;
       this.dialect = dialect;
+      this.librarySet = librarySet;
       this.relFn = relFn;
       this.transforms = ImmutableList.copyOf(transforms);
       this.parserConfig = parserConfig;
@@ -8926,13 +8940,13 @@ class RelToSqlConverterTest {
     }
 
     Sql dialect(SqlDialect dialect) {
-      return new Sql(schema, sql, dialect, parserConfig, config, relFn,
-          transforms);
+      return new Sql(schema, sql, dialect, parserConfig, librarySet, config,
+          relFn, transforms);
     }
 
     Sql relFn(Function<RelBuilder, RelNode> relFn) {
-      return new Sql(schema, sql, dialect, parserConfig, config, relFn,
-          transforms);
+      return new Sql(schema, sql, dialect, parserConfig, librarySet, config,
+          relFn, transforms);
     }
 
     Sql withCalcite() {
@@ -9079,18 +9093,27 @@ class RelToSqlConverterTest {
     }
 
     Sql parserConfig(SqlParser.Config parserConfig) {
-      return new Sql(schema, sql, dialect, parserConfig, config, relFn,
-          transforms);
+      return new Sql(schema, sql, dialect, parserConfig, librarySet, config,
+          relFn, transforms);
     }
 
     Sql withConfig(UnaryOperator<SqlToRelConverter.Config> config) {
-      return new Sql(schema, sql, dialect, parserConfig, config, relFn,
-          transforms);
+      return new Sql(schema, sql, dialect, parserConfig, librarySet, config,
+          relFn, transforms);
+    }
+
+    final Sql withLibrary(SqlLibrary library) {
+      return withLibrarySet(ImmutableSet.of(library));
+    }
+
+    Sql withLibrarySet(Iterable<? extends SqlLibrary> librarySet) {
+      return new Sql(schema, sql, dialect, parserConfig,
+          ImmutableSet.copyOf(librarySet), config, relFn, transforms);
     }
 
     Sql optimize(final RuleSet ruleSet, final RelOptPlanner relOptPlanner) {
-      return new Sql(schema, sql, dialect, parserConfig, config, relFn,
-          FlatLists.append(transforms, r -> {
+      final List<Function<RelNode, RelNode>> transforms =
+          FlatLists.append(this.transforms, r -> {
             Program program = Programs.of(ruleSet);
             final RelOptPlanner p =
                 Util.first(relOptPlanner,
@@ -9099,7 +9122,9 @@ class RelToSqlConverterTest {
                             .build()));
             return program.run(p, r, r.getTraitSet(),
                 ImmutableList.of(), ImmutableList.of());
-          }));
+          });
+      return new Sql(schema, sql, dialect, parserConfig, librarySet, config,
+          relFn, transforms);
     }
 
     Sql ok(String expectedQuery) {
@@ -9127,7 +9152,7 @@ class RelToSqlConverterTest {
           final SqlToRelConverter.Config config = this.config.apply(SqlToRelConverter.config()
               .withTrimUnusedFields(false));
           final Planner planner =
-              getPlanner(null, parserConfig, schema, config);
+              getPlanner(null, parserConfig, schema, config, librarySet);
           SqlNode parse = planner.parse(sql);
           SqlNode validate = planner.validate(parse);
           rel = planner.rel(validate).rel;
@@ -9142,8 +9167,8 @@ class RelToSqlConverterTest {
     }
 
     public Sql schema(CalciteAssert.SchemaSpec schemaSpec) {
-      return new Sql(schemaSpec, sql, dialect, parserConfig, config, relFn,
-          transforms);
+      return new Sql(schemaSpec, sql, dialect, parserConfig, librarySet, config,
+          relFn, transforms);
     }
   }
 

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/ReltoSqlConverterArraysTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/ReltoSqlConverterArraysTest.java
@@ -165,7 +165,7 @@ class RelToSqlConverterArraysTest {
 
   private RelToSqlConverterTest.Sql sql(String sql) {
     return new RelToSqlConverterTest.Sql(ROOT_SCHEMA, sql,
-        CalciteSqlDialect.DEFAULT, SqlParser.Config.DEFAULT,
+        CalciteSqlDialect.DEFAULT, SqlParser.Config.DEFAULT, ImmutableSet.of(),
         UnaryOperator.identity(), null, ImmutableList.of());
   }
 

--- a/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -285,6 +285,7 @@ public class SqlParserTest {
       "HOURS",                                             "2011",
       "IDENTITY",                      "92", "99", "2003", "2011", "2014", "c",
       "IF",                            "92", "99", "2003",
+      "ILIKE",
       "IMMEDIATE",                     "92", "99", "2003",
       "IMMEDIATELY",
       "IMPORT",                                                            "c",
@@ -1798,7 +1799,20 @@ public class SqlParserTest {
             + "WHERE (`A` LIKE `B` ESCAPE `C`)) ESCAPE `D`)))");
   }
 
-  @Test void testFoo() {
+  @Test void testIlike() {
+    // The ILIKE operator is only valid when the PostgreSQL function library is
+    // enabled ('fun=postgresql'). But the parser can always parse it.
+    final String expected = "SELECT *\n"
+        + "FROM `T`\n"
+        + "WHERE (`X` NOT ILIKE '%abc%')";
+    final String sql = "select * from t where x not ilike '%abc%'";
+    sql(sql).ok(expected);
+
+    final String sql1 = "select * from t where x ilike '%abc%'";
+    final String expected1 = "SELECT *\n"
+        + "FROM `T`\n"
+        + "WHERE (`X` ILIKE '%abc%')";
+    sql(sql1).ok(expected1);
   }
 
   @Test void testArithmeticOperators() {

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlAdvisorTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlAdvisorTest.java
@@ -298,6 +298,7 @@ class SqlAdvisorTest extends SqlValidatorTestCase {
           "KEYWORD(CONTAINS)",
           "KEYWORD(EQUALS)",
           "KEYWORD(FORMAT)",
+          "KEYWORD(ILIKE)",
           "KEYWORD(IMMEDIATELY)",
           "KEYWORD(IN)",
           "KEYWORD(IS)",

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
@@ -3897,6 +3897,19 @@ public abstract class SqlOperatorBaseTest {
     tester.checkBoolean("'abbc' like 'a\\%c' escape '\\'", Boolean.FALSE);
   }
 
+  @Test void testIlikeEscape() {
+    tester.setFor(SqlLibraryOperators.ILIKE);
+    final SqlTester tester1 = libraryTester(SqlLibrary.POSTGRESQL);
+    tester1.checkBoolean("'a_c' ilike 'a#_C' escape '#'", Boolean.TRUE);
+    tester1.checkBoolean("'axc' ilike 'a#_C' escape '#'", Boolean.FALSE);
+    tester1.checkBoolean("'a_c' ilike 'a\\_C' escape '\\'", Boolean.TRUE);
+    tester1.checkBoolean("'axc' ilike 'a\\_C' escape '\\'", Boolean.FALSE);
+    tester1.checkBoolean("'a%c' ilike 'a\\%C' escape '\\'", Boolean.TRUE);
+    tester1.checkBoolean("'a%cde' ilike 'a\\%C_e' escape '\\'", Boolean.TRUE);
+    tester1.checkBoolean("'abbc' ilike 'a%C' escape '\\'", Boolean.TRUE);
+    tester1.checkBoolean("'abbc' ilike 'a\\%C' escape '\\'", Boolean.FALSE);
+  }
+
   @Disabled("[CALCITE-525] Exception-handling in built-in functions")
   @Test void testLikeEscape2() {
     tester.checkBoolean("'x' not like 'x' escape 'x'", Boolean.TRUE);
@@ -3927,6 +3940,48 @@ public abstract class SqlOperatorBaseTest {
     tester.checkBoolean("'ab\ncd\nef' like '%cde%'", Boolean.FALSE);
   }
 
+  @Test void testIlikeOperator() {
+    tester.setFor(SqlLibraryOperators.ILIKE);
+    final String noLike = "No match found for function signature ILIKE";
+    tester.checkFails("^'a' ilike 'b'^", noLike, false);
+    tester.checkFails("^'a' ilike 'b' escape 'c'^", noLike, false);
+    final String noNotLike = "No match found for function signature NOT ILIKE";
+    tester.checkFails("^'a' not ilike 'b'^", noNotLike, false);
+    tester.checkFails("^'a' not ilike 'b' escape 'c'^", noNotLike, false);
+
+    final SqlTester tester1 = libraryTester(SqlLibrary.POSTGRESQL);
+    tester1.checkBoolean("''  ilike ''", Boolean.TRUE);
+    tester1.checkBoolean("'a' ilike 'a'", Boolean.TRUE);
+    tester1.checkBoolean("'a' ilike 'b'", Boolean.FALSE);
+    tester1.checkBoolean("'a' ilike 'A'", Boolean.TRUE);
+    tester1.checkBoolean("'a' ilike 'a_'", Boolean.FALSE);
+    tester1.checkBoolean("'a' ilike '_a'", Boolean.FALSE);
+    tester1.checkBoolean("'a' ilike '%a'", Boolean.TRUE);
+    tester1.checkBoolean("'a' ilike '%A'", Boolean.TRUE);
+    tester1.checkBoolean("'a' ilike '%a%'", Boolean.TRUE);
+    tester1.checkBoolean("'a' ilike '%A%'", Boolean.TRUE);
+    tester1.checkBoolean("'a' ilike 'a%'", Boolean.TRUE);
+    tester1.checkBoolean("'a' ilike 'A%'", Boolean.TRUE);
+    tester1.checkBoolean("'ab'   ilike 'a_'", Boolean.TRUE);
+    tester1.checkBoolean("'ab'   ilike 'A_'", Boolean.TRUE);
+    tester1.checkBoolean("'abc'  ilike 'a_'", Boolean.FALSE);
+    tester1.checkBoolean("'abcd' ilike 'a%'", Boolean.TRUE);
+    tester1.checkBoolean("'abcd' ilike 'A%'", Boolean.TRUE);
+    tester1.checkBoolean("'ab'   ilike '_b'", Boolean.TRUE);
+    tester1.checkBoolean("'ab'   ilike '_B'", Boolean.TRUE);
+    tester1.checkBoolean("'abcd' ilike '_d'", Boolean.FALSE);
+    tester1.checkBoolean("'abcd' ilike '%d'", Boolean.TRUE);
+    tester1.checkBoolean("'abcd' ilike '%D'", Boolean.TRUE);
+    tester1.checkBoolean("'ab\ncd' ilike 'ab%'", Boolean.TRUE);
+    tester1.checkBoolean("'ab\ncd' ilike 'aB%'", Boolean.TRUE);
+    tester1.checkBoolean("'abc\ncd' ilike 'ab%'", Boolean.TRUE);
+    tester1.checkBoolean("'abc\ncd' ilike 'Ab%'", Boolean.TRUE);
+    tester1.checkBoolean("'123\n\n45\n' ilike '%'", Boolean.TRUE);
+    tester1.checkBoolean("'ab\ncd\nef' ilike '%cd%'", Boolean.TRUE);
+    tester1.checkBoolean("'ab\ncd\nef' ilike '%CD%'", Boolean.TRUE);
+    tester1.checkBoolean("'ab\ncd\nef' ilike '%cde%'", Boolean.FALSE);
+  }
+
   /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-1898">[CALCITE-1898]
    * LIKE must match '.' (period) literally</a>. */
@@ -3934,6 +3989,15 @@ public abstract class SqlOperatorBaseTest {
     tester.checkBoolean("'abc' like 'a.c'", Boolean.FALSE);
     tester.checkBoolean("'abcde' like '%c.e'", Boolean.FALSE);
     tester.checkBoolean("'abc.e' like '%c.e'", Boolean.TRUE);
+  }
+
+  @Test void testIlikeDot() {
+    tester.setFor(SqlLibraryOperators.ILIKE);
+    final SqlTester tester1 = libraryTester(SqlLibrary.POSTGRESQL);
+    tester1.checkBoolean("'abc' ilike 'a.c'", Boolean.FALSE);
+    tester1.checkBoolean("'abcde' ilike '%c.e'", Boolean.FALSE);
+    tester1.checkBoolean("'abc.e' ilike '%c.e'", Boolean.TRUE);
+    tester1.checkBoolean("'abc.e' ilike '%c.E'", Boolean.TRUE);
   }
 
   @Test void testNotSimilarToOperator() {

--- a/core/src/test/java/org/apache/calcite/test/RelBuilderTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelBuilderTest.java
@@ -53,6 +53,7 @@ import org.apache.calcite.schema.impl.ViewTable;
 import org.apache.calcite.schema.impl.ViewTableMacro;
 import org.apache.calcite.sql.SqlMatchRecognize;
 import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.fun.SqlLibraryOperators;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.parser.SqlParser;
 import org.apache.calcite.sql.type.SqlTypeName;
@@ -3971,13 +3972,27 @@ public class RelBuilderTest {
     RelNode root =
         builder.scan("EMP")
             .filter(
-                builder.call(
-                    SqlStdOperatorTable.NOT_LIKE,
+                builder.call(SqlStdOperatorTable.NOT_LIKE,
                     builder.field("ENAME"),
                     builder.literal("a%b%c")))
             .build();
     final String expected = ""
         + "LogicalFilter(condition=[NOT(LIKE($1, 'a%b%c'))])\n"
+        + "  LogicalTableScan(table=[[scott, EMP]])\n";
+    assertThat(root, hasTree(expected));
+  }
+
+  @Test void testNotIlike() {
+    final RelBuilder builder = RelBuilder.create(config().build());
+    RelNode root =
+        builder.scan("EMP")
+            .filter(
+                builder.call(SqlLibraryOperators.NOT_ILIKE,
+                    builder.field("ENAME"),
+                    builder.literal("a%b%c")))
+            .build();
+    final String expected = ""
+        + "LogicalFilter(condition=[NOT(ILIKE($1, 'a%b%c'))])\n"
         + "  LogicalTableScan(table=[[scott, EMP]])\n";
     assertThat(root, hasTree(expected));
   }

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -1005,6 +1005,19 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
     expr("'a' similar to 'b' escape 'c'").ok();
   }
 
+  @Test void testIlike() {
+    final Sql s = sql("?")
+        .withOperatorTable(operatorTableFor(SqlLibrary.POSTGRESQL));
+    s.expr("'a' ilike 'b'").columnType("BOOLEAN NOT NULL");
+    s.expr("'a' ilike cast(null as varchar(99))").columnType("BOOLEAN");
+    s.expr("cast(null as varchar(99)) not ilike 'b'").columnType("BOOLEAN");
+    s.expr("'a' not ilike 'b' || 'c'").columnType("BOOLEAN NOT NULL");
+
+    // ILIKE is only available in the PostgreSQL function library
+    expr("^'a' ilike 'b'^")
+        .fails("No match found for function signature ILIKE");
+  }
+
   public void _testLikeAndSimilarFails() {
     expr("'a' like _UTF16'b'  escape 'c'")
         .fails("(?s).*Operands _ISO-8859-1.a. COLLATE ISO-8859-1.en_US.primary,"

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -655,6 +655,7 @@ HOP,
 HOURS,
 **IDENTITY**,
 IGNORE,
+ILIKE,
 IMMEDIATE,
 IMMEDIATELY,
 IMPLEMENTATION,
@@ -2544,6 +2545,8 @@ semantics.
 | m | EXTRACTVALUE(xml, xpathExpr))                  | Returns the text of the first text node which is a child of the element or elements matched by the XPath expression.
 | o | GREATEST(expr [, expr ]*)                      | Returns the greatest of the expressions
 | b h s | IF(condition, value1, value2)              | Returns *value1* if *condition* is TRUE, *value2* otherwise
+| p | string1 ILIKE string2 [ ESCAPE string3 ]       | Whether *string1* matches pattern *string2*, ignoring case (similar to `LIKE`)
+| p | string1 NOT ILIKE string2 [ ESCAPE string3 ]   | Whether *string1* does not match pattern *string2*, ignoring case (similar to `NOT LIKE`)
 | m | JSON_TYPE(jsonValue)                           | Returns a string value indicating the type of *jsonValue*
 | m | JSON_DEPTH(jsonValue)                          | Returns an integer value indicating the depth of *jsonValue*
 | m | JSON_PRETTY(jsonValue)                         | Returns a pretty-printing of *jsonValue*


### PR DESCRIPTION
…PostgreSQL-specific) (Ondřej Štumpf)

Add method SqlOperator.not(), and remove
SqlImplementor.NOT_KIND_OPERATORS map. (Julian Hyde)

In RelToSqlConverterTest, allow Set<SqlLibrary> as part of test configuration. (Julian Hyde)

Close apache/calcite#2317

(cherry picked from commit 174a707e1c199c97d7cc3531f0cd2e94745f4366)