### PR TITLE
RAVTDBQ-450: Support for INTERVAL Datatypes in DDL

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
@@ -1927,6 +1927,10 @@ public class BigQuerySqlDialect extends SqlDialect {
       case INTERVAL_DAY_SECOND:
       case INTERVAL_DAY_MINUTE:
       case INTERVAL_DAY_HOUR:
+      case INTERVAL_DAY:
+      case INTERVAL_HOUR:
+      case INTERVAL_MINUTE:
+      case INTERVAL_MONTH:
         return createSqlDataTypeSpecByName("INT64", typeName);
       // BigQuery only supports FLOAT64(aka. Double) for floating point types.
       case FLOAT:

--- a/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
@@ -1931,6 +1931,8 @@ public class BigQuerySqlDialect extends SqlDialect {
       case INTERVAL_HOUR:
       case INTERVAL_MINUTE:
       case INTERVAL_MONTH:
+      case INTERVAL_SECOND:
+      case INTERVAL_YEAR:
         return createSqlDataTypeSpecByName("INT64", typeName);
       // BigQuery only supports FLOAT64(aka. Double) for floating point types.
       case FLOAT:


### PR DESCRIPTION
RAVTDBQ-450: Support for INTERVAL_DAY, INTERVAL_HOUR, INTERVAL_MINUTE, and INTERVAL_MONTH data types in DDL.