### PR TITLE
RAVTDBQ-576- function support for edit_distance

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
@@ -1398,6 +1398,13 @@ public class BigQuerySqlDialect extends SqlDialect {
     case "SHIFTRIGHT":
       unparseShiftLeftAndShiftRight(writer, call, false);
       break;
+    case "EDIT_DISTANCE":
+      if (call.operandCount() == 3) {
+        unparseEditDistanceForThreeArgs(writer, call, leftPrec, rightPrec);
+      } else {
+        call.getOperator().unparse(writer, call, leftPrec, rightPrec);
+      }
+      break;
     default:
       super.unparseCall(writer, call, leftPrec, rightPrec);
     }
@@ -2316,5 +2323,17 @@ public class BigQuerySqlDialect extends SqlDialect {
         ? "r'[^" + ((SqlCharStringLiteral) secondOperand).toValue() + "]+'"
         : secondOperand.toString();
     writer.print(pattern);
+  }
+
+  private void unparseEditDistanceForThreeArgs(SqlWriter writer, SqlCall call, int leftPrec,
+      int rightPrec) {
+    final SqlWriter.Frame editDistanceFunctionFrame = writer.startFunCall("EDIT_DISTANCE");
+    call.operand(0).unparse(writer, leftPrec, rightPrec);
+    writer.print(",");
+    call.operand(1).unparse(writer, leftPrec, rightPrec);
+    writer.print(",");
+    writer.print("max_distance => ");
+    call.operand(2).unparse(writer, leftPrec, rightPrec);
+    writer.endFunCall(editDistanceFunctionFrame);
   }
 }

--- a/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
@@ -2328,12 +2328,11 @@ public class BigQuerySqlDialect extends SqlDialect {
   private void unparseEditDistanceForThreeArgs(SqlWriter writer, SqlCall call, int leftPrec,
       int rightPrec) {
     final SqlWriter.Frame editDistanceFunctionFrame = writer.startFunCall("EDIT_DISTANCE");
-    call.operand(0).unparse(writer, leftPrec, rightPrec);
-    writer.print(",");
-    call.operand(1).unparse(writer, leftPrec, rightPrec);
-    writer.print(",");
-    writer.print("max_distance => ");
-    call.operand(2).unparse(writer, leftPrec, rightPrec);
+    for (int i = 0; i < 3; i++) {
+      writer.print((i > 0) ? "," : "");
+      writer.print((i == 2) ? "max_distance => " : "");
+      call.operand(i).unparse(writer, leftPrec, rightPrec);
+    }
     writer.endFunCall(editDistanceFunctionFrame);
   }
 }

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -1979,4 +1979,14 @@ public abstract class SqlLibraryOperators {
           ReturnTypes.ARG0, null,
           OperandTypes.family(SqlTypeFamily.NUMERIC),
           SqlFunctionCategory.NUMERIC);
+
+  @LibraryOperator(libraries = {BIG_QUERY, ORACLE})
+  public static final SqlFunction EDIT_DISTANCE =
+      new SqlFunction("EDIT_DISTANCE",
+          SqlKind.OTHER_FUNCTION,
+          ReturnTypes.INTEGER_NULLABLE, null,
+          OperandTypes.family(ImmutableList.of(SqlTypeFamily.STRING, SqlTypeFamily.STRING,
+                  SqlTypeFamily.NUMERIC),
+              number -> number == 2),
+          SqlFunctionCategory.NUMERIC);
 }

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -1986,7 +1986,7 @@ public abstract class SqlLibraryOperators {
           SqlKind.OTHER_FUNCTION,
           ReturnTypes.INTEGER_NULLABLE, null,
           OperandTypes.family(ImmutableList.of(SqlTypeFamily.STRING, SqlTypeFamily.STRING,
-                  SqlTypeFamily.NUMERIC),
+                  SqlTypeFamily.INTEGER),
               number -> number == 2),
           SqlFunctionCategory.NUMERIC);
 }

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -13634,4 +13634,33 @@ class RelToSqlConverterTest {
 
     assertThat(toSql(root, DatabaseProduct.BIG_QUERY.getDialect()), isLinux(expectedBiqQuery));
   }
+
+  @Test public void testEdit_DistanceFunctionWithTwoArgs() {
+    final RelBuilder builder = relBuilder();
+    final RexNode editDistanceRex = builder.call(SqlLibraryOperators.EDIT_DISTANCE,
+        builder.literal("abc"), builder.literal("xyz"));
+    final RelNode root = builder
+        .scan("EMP")
+        .project(editDistanceRex)
+        .build();
+    final String expectedBQQuery = "SELECT EDIT_DISTANCE('abc', 'xyz') AS `$f0`\n" +
+        "FROM scott.EMP";
+    assertThat(toSql(root, DatabaseProduct.BIG_QUERY.getDialect()), isLinux(expectedBQQuery));
+  }
+
+  @Test
+  public void testEdit_DistanceFunctionWithThreeArgs() {
+    final RelBuilder builder = relBuilder();
+    final RexNode editDistanceRex = builder.call(SqlLibraryOperators.EDIT_DISTANCE,
+        builder.literal("abc"), builder.literal("xyz"),
+        builder.literal(2));
+    final RelNode root = builder
+        .scan("EMP")
+        .project(editDistanceRex)
+        .build();
+    final String expectedBQQuery = "SELECT EDIT_DISTANCE('abc', 'xyz', max_distance => 2) AS " +
+        "`$f0`\n" +
+        "FROM scott.EMP";
+    assertThat(toSql(root, DatabaseProduct.BIG_QUERY.getDialect()), isLinux(expectedBQQuery));
+  }
 }

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -13658,9 +13658,9 @@ class RelToSqlConverterTest {
         .scan("EMP")
         .project(editDistanceRex)
         .build();
-    final String expectedBQQuery = "SELECT EDIT_DISTANCE('abc', 'xyz', max_distance => 2) AS " +
+    final String expectedBqQuery = "SELECT EDIT_DISTANCE('abc', 'xyz', max_distance => 2) AS " +
         "`$f0`\n" +
         "FROM scott.EMP";
-    assertThat(toSql(root, DatabaseProduct.BIG_QUERY.getDialect()), isLinux(expectedBQQuery));
+    assertThat(toSql(root, DatabaseProduct.BIG_QUERY.getDialect()), isLinux(expectedBqQuery));
   }
 }


### PR DESCRIPTION
This pull request introduces support for the edit_distance function in DM-Calcite, specifically tailored for the BigQuery SQL dialect. The edit_distance function calculates the Levenshtein edit distance between two strings, providing a valuable tool for string similarity analysis in BigQuery.

Changes:

Implemented the edit_distance function.
Ensured compatibility with the BigQuery SQL dialect.
Accompanied by unit tests to validate accuracy and functionality.