### PR TITLE
Inderjeetvishnoi/optimizes-star-projection

### DIFF
--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -13634,4 +13634,25 @@ class RelToSqlConverterTest {
 
     assertThat(toSql(root, DatabaseProduct.BIG_QUERY.getDialect()), isLinux(expectedBiqQuery));
   }
+
+  @Test
+  void testColumnListWithAstericProjection() {
+    final RelBuilder builder = relBuilder().scan("EMP");
+    final RelNode rel = builder.project(builder.field(0), builder.field(0), builder.field(1),
+        builder.field(2), builder.field(3), builder.field(4), builder.field(5), builder.field(6),
+        builder.field(7)).build();
+    final String expectedBigQuery = "SELECT EMPNO, *\nFROM scott.EMP";
+    assertThat(toSql(rel, DatabaseProduct.BIG_QUERY.getDialect()), isLinux(expectedBigQuery));
+  }
+
+  @Test
+  void testColumnListWithAstericProjection1() {
+    final RelBuilder builder = relBuilder().scan("EMP");
+    final RelNode rel = builder.project(builder.field(0), builder.field(0), builder.field(1),
+        builder.field(2), builder.field(3), builder.field(4), builder.field(5), builder.field(6),
+        builder.field(7), builder.field(2)).build();
+    final String expectedBigQuery = "SELECT EMPNO, *, JOB AS JOB0\nFROM scott.EMP";
+    assertThat(toSql(rel, DatabaseProduct.BIG_QUERY.getDialect()), isLinux(expectedBigQuery));
+  }
+
 }


### PR DESCRIPTION
This PR intends to optimize the star prjection[if present] in the projection list. 

Example: 
Source query : :select column1,* from table1; 
- calcite flattens *  while building the LogicalProject of this query, which would have the entire columnlist/feilds in the Project rel [column1 being repeated there]
- toSql of above rel results in the flattened column-list in place of *.

With changes of this PR, we would check if the project rel has flattened * in the project list, if yes, replace this flattened projection sublist with `SQLIdentifier.STAR.`
