### PR TITLE
Control simplification in "RelBuilder#filter" in calcite

### DIFF
--- a/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
+++ b/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
@@ -1316,22 +1316,29 @@ public class RelBuilder {
    *
    * <p>The predicates are combined using AND,
    * and optimized in a similar way to the {@link #and} method.
-   * If the result is TRUE no filter is created. */
+   * If simplification is on and the result is TRUE, no filter is created. */
   public RelBuilder filter(Iterable<CorrelationId> variablesSet,
       Iterable<? extends RexNode> predicates) {
-    final RexNode simplifiedPredicates =
-        simplifier.simplifyFilterPredicates(predicates);
-    if (simplifiedPredicates == null) {
-      return empty();
+    final RexNode conjunctionPredicates;
+    if (config.simplify()) {
+      conjunctionPredicates = simplifier.simplifyFilterPredicates(predicates);
+    } else {
+      conjunctionPredicates =
+          RexUtil.composeConjunction(simplifier.rexBuilder, predicates);
     }
 
-    if (!simplifiedPredicates.isAlwaysTrue()) {
-      final Frame frame = stack.pop();
-      final RelNode filter =
-          struct.filterFactory.createFilter(frame.rel,
-              simplifiedPredicates, ImmutableSet.copyOf(variablesSet));
-      stack.push(new Frame(filter, frame.fields));
+    if (conjunctionPredicates == null || conjunctionPredicates.isAlwaysFalse()) {
+      return empty();
     }
+    if (conjunctionPredicates.isAlwaysTrue()) {
+      return this;
+    }
+
+    final Frame frame = stack.pop();
+    final RelNode filter =
+        struct.filterFactory.createFilter(frame.rel,
+            conjunctionPredicates, ImmutableSet.copyOf(variablesSet));
+    stack.push(new Frame(filter, frame.fields));
     return this;
   }
 

--- a/core/src/test/java/org/apache/calcite/test/RelBuilderTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelBuilderTest.java
@@ -3590,6 +3590,24 @@ public class RelBuilderTest {
     assertThat(root, hasTree("LogicalValues(tuples=[[]])\n"));
   }
 
+  @Test void testFilterWithoutSimplification() {
+    final RelBuilder builder = createBuilder(c -> c.withSimplify(false));
+    final RelNode root =
+        builder.scan("EMP")
+            .filter(
+                builder.or(
+                    builder.literal(null),
+                    builder.and(
+                        builder.equals(builder.field(2), builder.literal(1)),
+                        builder.equals(builder.field(2), builder.literal(2))
+                    )))
+            .build();
+    final String expected = ""
+        + "LogicalFilter(condition=[OR(null:NULL, AND(=($2, 1), =($2, 2)))])\n"
+        + "  LogicalTableScan(table=[[scott, EMP]])\n";
+    assertThat(root, hasTree(expected));
+  }
+
   @Test void testRelBuilderToString() {
     final RelBuilder builder = RelBuilder.create(config().build());
     builder.scan("EMP");


### PR DESCRIPTION
Recently, we have encountered a new corner case related to Logical filters in our RelNodes. Specifically, when the filter condition is set to 1=2, the expression gets simplified, resulting in the filter always evaluating to false.

Upon thorough analysis, it has been identified that there is currently no configurable support for simplifying expressions in filters within Datamatica Calcite.

As support for the same was already added into calcite we just need to find changes and test-cases for the same and pulled into dm calcite.

