### PR TITLE
Renamed RelToSqlConverterTest, so that we can easily pull changes fro…

### DIFF
--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
@@ -172,7 +172,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Tests for {@link RelToSqlConverter}.
  */
-class RelToSqlConverterTest {
+class RelToSqlConverterDMTest {
 
   /** Initiates a test case with a given SQL query. */
   private Sql sql(String sql) {

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterStructsTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterStructsTest.java
@@ -162,8 +162,8 @@ class RelToSqlConverterStructsTest {
   private static final SchemaPlus ROOT_SCHEMA = CalciteSchema
       .createRootSchema(false).add("myDb", SCHEMA).plus();
 
-  private RelToSqlConverterTest.Sql sql(String sql) {
-    return new RelToSqlConverterTest.Sql(ROOT_SCHEMA, sql,
+  private RelToSqlConverterDMTest.Sql sql(String sql) {
+    return new RelToSqlConverterDMTest.Sql(ROOT_SCHEMA, sql,
         CalciteSqlDialect.DEFAULT, SqlParser.Config.DEFAULT, ImmutableSet.of(),
         UnaryOperator.identity(), null, ImmutableList.of());
   }

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/ReltoSqlConverterArraysTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/ReltoSqlConverterArraysTest.java
@@ -163,8 +163,8 @@ class RelToSqlConverterArraysTest {
   private static final SchemaPlus ROOT_SCHEMA = CalciteSchema
       .createRootSchema(false).add("myDb", SCHEMA).plus();
 
-  private RelToSqlConverterTest.Sql sql(String sql) {
-    return new RelToSqlConverterTest.Sql(ROOT_SCHEMA, sql,
+  private RelToSqlConverterDMTest.Sql sql(String sql) {
+    return new RelToSqlConverterDMTest.Sql(ROOT_SCHEMA, sql,
         CalciteSqlDialect.DEFAULT, SqlParser.Config.DEFAULT, ImmutableSet.of(),
         UnaryOperator.identity(), null, ImmutableList.of());
   }


### PR DESCRIPTION
Renamed RelToSqlConverterTest, so that we can easily pull changes from apache calcite