### PR TITLE
Sql select qualify support

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlSelectOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlSelectOperator.java
@@ -74,11 +74,12 @@ public class SqlSelectOperator extends SqlOperator {
         operands[3],
         (SqlNodeList) operands[4],
         operands[5],
-        (SqlNodeList) operands[6],
+        operands[6],
         (SqlNodeList) operands[7],
-        operands[8],
+        (SqlNodeList) operands[8],
         operands[9],
-        (SqlNodeList) operands[10]);
+        operands[10],
+        (SqlNodeList) operands[11]);
   }
 
   /**

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
@@ -300,8 +300,7 @@ class RelToSqlConverterDMTest {
    * and with a particular writer configuration. */
   private static String toSql(RelNode root, SqlDialect dialect,
       UnaryOperator<SqlWriterConfig> transform) {
-    final RelToSqlConverter converter = new RelToSqlConverter(dialect);
-    final SqlNode sqlNode = converter.visitRoot(root).asStatement();
+    final SqlNode sqlNode = toSqlNode(root, dialect);
     return sqlNode.toSqlString(c -> transform.apply(c.withDialect(dialect)))
         .getSql();
   }
@@ -11532,26 +11531,7 @@ class RelToSqlConverterDMTest {
   }
 
   @Test public void testQualify() {
-    RelBuilder builder = relBuilder().scan("EMP");
-    RexNode aggregateFunRexNode = builder.call(SqlStdOperatorTable.MAX, builder.field(0));
-    RelDataType type = aggregateFunRexNode.getType();
-    RexFieldCollation orderKeys = new RexFieldCollation(
-        builder.field("HIREDATE"),
-        ImmutableSet.of());
-    final RexNode analyticalFunCall = builder.getRexBuilder().makeOver(type,
-        SqlStdOperatorTable.MAX,
-        ImmutableList.of(builder.field(0)), ImmutableList.of(), ImmutableList.of(orderKeys),
-        RexWindowBounds.UNBOUNDED_PRECEDING,
-        RexWindowBounds.UNBOUNDED_FOLLOWING,
-        true, true, false, false, false);
-    final RexNode equalsNode =
-        builder.getRexBuilder().makeCall(EQUALS,
-            new RexInputRef(1, analyticalFunCall.getType()), builder.literal(1));
-    final RelNode root = builder
-        .project(builder.field("HIREDATE"), builder.alias(analyticalFunCall, "EXPR$"))
-        .filter(equalsNode)
-        .project(builder.field("HIREDATE"))
-        .build();
+    final RelNode root = createRelNodeWithQualifyStatement();
     final String expectedSparkQuery = "SELECT HIREDATE\n"
         + "FROM scott.EMP\n"
         + "QUALIFY (MAX(EMPNO) OVER (ORDER BY HIREDATE IS NULL, HIREDATE ROWS BETWEEN UNBOUNDED "
@@ -11560,29 +11540,11 @@ class RelToSqlConverterDMTest {
   }
 
   @Test public void testQualifyForSqlSelectCall() {
-    RelBuilder builder = relBuilder().scan("EMP");
-    RexNode aggregateFunRexNode = builder.call(SqlStdOperatorTable.MAX, builder.field(0));
-    RelDataType type = aggregateFunRexNode.getType();
-    RexFieldCollation orderKeys = new RexFieldCollation(
-        builder.field("HIREDATE"),
-        ImmutableSet.of());
-    final RexNode analyticalFunCall = builder.getRexBuilder().makeOver(type,
-        SqlStdOperatorTable.MAX,
-        ImmutableList.of(builder.field(0)), ImmutableList.of(), ImmutableList.of(orderKeys),
-        RexWindowBounds.UNBOUNDED_PRECEDING,
-        RexWindowBounds.UNBOUNDED_FOLLOWING,
-        true, true, false, false, false);
-    final RexNode equalsNode =
-        builder.getRexBuilder().makeCall(EQUALS,
-            new RexInputRef(1, analyticalFunCall.getType()), builder.literal(1));
-    final RelNode root = builder
-        .project(builder.field("HIREDATE"), builder.alias(analyticalFunCall, "EXPR$"))
-        .filter(equalsNode)
-        .project(builder.field("HIREDATE"))
-        .build();
+    final RelNode root = createRelNodeWithQualifyStatement();
     SqlCall call = (SqlCall) toSqlNode(root, DatabaseProduct.BIG_QUERY.getDialect());
     List<SqlNode> operands = call.getOperandList();
-    String  generatedSql = String.valueOf(call.getOperator().createCall(
+    String  generatedSql = String.valueOf(
+        call.getOperator().createCall(
         null, SqlParserPos.ZERO, operands).toSqlString(DatabaseProduct.SPARK.getDialect()));
     String expectedSql = "SELECT HIREDATE\n"
         + "FROM scott.EMP\n"
@@ -14150,4 +14112,28 @@ class RelToSqlConverterDMTest {
 
     assertThat(toSql(root, DatabaseProduct.BIG_QUERY.getDialect()), isLinux(expectedBiqQuery));
   }
+
+  private RelNode createRelNodeWithQualifyStatement() {
+    RelBuilder builder = relBuilder().scan("EMP");
+    RexNode aggregateFunRexNode = builder.call(SqlStdOperatorTable.MAX, builder.field(0));
+    RelDataType type = aggregateFunRexNode.getType();
+    RexFieldCollation orderKeys = new RexFieldCollation(
+        builder.field("HIREDATE"),
+        ImmutableSet.of());
+    final RexNode analyticalFunCall = builder.getRexBuilder().makeOver(type,
+        SqlStdOperatorTable.MAX,
+        ImmutableList.of(builder.field(0)), ImmutableList.of(), ImmutableList.of(orderKeys),
+        RexWindowBounds.UNBOUNDED_PRECEDING,
+        RexWindowBounds.UNBOUNDED_FOLLOWING,
+        true, true, false, false, false);
+    final RexNode equalsNode =
+        builder.getRexBuilder().makeCall(EQUALS,
+            new RexInputRef(1, analyticalFunCall.getType()), builder.literal(1));
+    return builder
+        .project(builder.field("HIREDATE"), builder.alias(analyticalFunCall, "EXPR$"))
+        .filter(equalsNode)
+        .project(builder.field("HIREDATE"))
+        .build();
+  }
+
 }

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
@@ -305,7 +305,7 @@ class RelToSqlConverterDMTest {
         .getSql();
   }
 
-  /** Converts a relational expression to SQL Node */
+  /** Converts a relational expression to SQL Node. */
   private static SqlNode toSqlNode(RelNode root, SqlDialect dialect) {
     final RelToSqlConverter converter = new RelToSqlConverter(dialect);
     return converter.visitRoot(root).asStatement();


### PR DESCRIPTION
Select query having "Qualify" keyword is failing when revisited using shuttle. 
Cause : createCall method in SqlSelectOperator is calling incorrect constructor of SqlSelect that does does not expect qualify in operandlist.