### PR TITLE
Julian enum support

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlDateTimeFormat.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDateTimeFormat.java
@@ -85,6 +85,7 @@ public enum SqlDateTimeFormat {
   SEC_FROM_MIDNIGHT("SEC_FROM_MIDNIGHT"),
   E4("E4"),
   E3("E3"),
+  JULIAN("J"),
   U("u"),
   NUMERIC_TIME_ZONE("ZZ"),
   QUARTER("QUARTER"),

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
@@ -11530,6 +11530,21 @@ class RelToSqlConverterDMTest {
     assertThat(toSql(root, DatabaseProduct.SPARK.getDialect()), isLinux(expectedSparkQuery));
   }
 
+  @Test public void testForToCharWithJulian() {
+    final RelBuilder builder = relBuilder();
+
+    final RexNode toCharWithDate = builder.call(SqlLibraryOperators.TO_CHAR,
+        builder.getRexBuilder().makeDateLiteral(new DateString("1970-01-01")),
+        builder.literal("J"));
+    final RelNode root = builder
+        .scan("EMP")
+        .project(builder.alias(toCharWithDate, "FD"))
+        .build();
+    final String expectedSparkQuery = "SELECT TO_CHAR(TO_DATE('1970-01-01', 'YYYY-MM-DD'), 'J') " +
+        "\"FD\"\nFROM \"scott\".\"EMP\"";
+    assertThat(toSql(root, DatabaseProduct.ORACLE.getDialect()), isLinux(expectedSparkQuery));
+  }
+
   @Test public void testQualify() {
     final RelNode root = createRelNodeWithQualifyStatement();
     final String expectedSparkQuery = "SELECT HIREDATE\n"

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
@@ -11540,9 +11540,9 @@ class RelToSqlConverterDMTest {
         .scan("EMP")
         .project(builder.alias(toCharWithDate, "FD"))
         .build();
-    final String expectedSparkQuery = "SELECT TO_CHAR(TO_DATE('1970-01-01', 'YYYY-MM-DD'), 'J') "
+    final String expectedOracleQuery = "SELECT TO_CHAR(TO_DATE('1970-01-01', 'YYYY-MM-DD'), 'J') "
         + "\"FD\"\nFROM \"scott\".\"EMP\"";
-    assertThat(toSql(root, DatabaseProduct.ORACLE.getDialect()), isLinux(expectedSparkQuery));
+    assertThat(toSql(root, DatabaseProduct.ORACLE.getDialect()), isLinux(expectedOracleQuery));
   }
 
   @Test public void testQualify() {

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
@@ -11540,8 +11540,8 @@ class RelToSqlConverterDMTest {
         .scan("EMP")
         .project(builder.alias(toCharWithDate, "FD"))
         .build();
-    final String expectedSparkQuery = "SELECT TO_CHAR(TO_DATE('1970-01-01', 'YYYY-MM-DD'), 'J') " +
-        "\"FD\"\nFROM \"scott\".\"EMP\"";
+    final String expectedSparkQuery = "SELECT TO_CHAR(TO_DATE('1970-01-01', 'YYYY-MM-DD'), 'J') "
+        + "\"FD\"\nFROM \"scott\".\"EMP\"";
     assertThat(toSql(root, DatabaseProduct.ORACLE.getDialect()), isLinux(expectedSparkQuery));
   }
 


### PR DESCRIPTION
Oracle supports Julian Date format, adding an enum value to make system parse the julian date format.