### PR TITLE
RSFB-3327/Concat2 Function Unparsing related changes

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/dialect/PostgresqlSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/PostgresqlSqlDialect.java
@@ -215,6 +215,13 @@ public class PostgresqlSqlDialect extends SqlDialect {
     case OTHER:
       this.unparseOtherFunction(writer, call, leftPrec, rightPrec);
       break;
+    case CONCAT2:
+      SqlWriter.Frame concat = writer.startFunCall("CONCAT");
+      call.operand(0).unparse(writer, leftPrec, rightPrec);
+      writer.print(",");
+      call.operand(1).unparse(writer, leftPrec, rightPrec);
+      writer.endFunCall(concat);
+      break;
     default:
       super.unparseCall(writer, call, leftPrec, rightPrec);
     }

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
@@ -3386,6 +3386,20 @@ class RelToSqlConverterDMTest {
     assertThat(toSql(root, DatabaseProduct.BIG_QUERY.getDialect()), isLinux(expectedBiqQuery));
   }
 
+  @Test public void testConcat2FunctionWithBooleanArgumentRelToSql() {
+    final RelBuilder builder = relBuilder();
+    final RexNode concatRexNode =
+        builder.call(SqlLibraryOperators.CONCAT2, builder.literal("foo"),
+            builder.literal("bar"), builder.literal("true"));
+    final RelNode root = builder
+        .scan("EMP")
+        .project(builder.alias(concatRexNode, "CR"))
+        .build();
+    final String expectedSql = "SELECT CONCAT('foo', 'bar') AS \"CR\"\n"
+        + "FROM \"scott\".\"EMP\"";
+    assertThat(toSql(root, DatabaseProduct.POSTGRESQL.getDialect()), isLinux(expectedSql));
+  }
+
   @Test public void testDateTimeDiffFunctionRelToSql() {
     final RelBuilder builder = relBuilder();
     final RexNode dateTimeDiffRexNode =

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
@@ -3386,7 +3386,8 @@ class RelToSqlConverterDMTest {
     assertThat(toSql(root, DatabaseProduct.BIG_QUERY.getDialect()), isLinux(expectedBiqQuery));
   }
 
-  @Test public void testConcat2FunctionWithBooleanArgumentRelToSql() {
+  @Test
+  public void testConcat2FunctionWithBooleanArgument() {
     final RelBuilder builder = relBuilder();
     final RexNode concatRexNode =
         builder.call(SqlLibraryOperators.CONCAT2, builder.literal("foo"),
@@ -3395,9 +3396,12 @@ class RelToSqlConverterDMTest {
         .scan("EMP")
         .project(builder.alias(concatRexNode, "CR"))
         .build();
-    final String expectedSql = "SELECT CONCAT('foo', 'bar') AS \"CR\"\n"
-        + "FROM \"scott\".\"EMP\"";
-    assertThat(toSql(root, DatabaseProduct.POSTGRESQL.getDialect()), isLinux(expectedSql));
+    final String expectedSql = "SELECT CONCAT('foo', 'bar', 'true') AS \"CR\"\n" + "FROM " +
+        "\"scott\".\"EMP\"";
+    final String expectedPostgresSql = "SELECT CONCAT('foo', 'bar') AS \"CR\"\n" + "FROM " +
+        "\"scott\".\"EMP\"";
+    assertThat(toSql(root, DatabaseProduct.CALCITE.getDialect()), isLinux(expectedSql));
+    assertThat(toSql(root, DatabaseProduct.POSTGRESQL.getDialect()), isLinux(expectedPostgresSql));
   }
 
   @Test public void testDateTimeDiffFunctionRelToSql() {

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
@@ -3386,8 +3386,7 @@ class RelToSqlConverterDMTest {
     assertThat(toSql(root, DatabaseProduct.BIG_QUERY.getDialect()), isLinux(expectedBiqQuery));
   }
 
-  @Test
-  public void testConcat2FunctionWithBooleanArgument() {
+  @Test public void testConcat2FunctionWithBooleanArgument() {
     final RelBuilder builder = relBuilder();
     final RexNode concatRexNode =
         builder.call(SqlLibraryOperators.CONCAT2, builder.literal("foo"),
@@ -3396,10 +3395,10 @@ class RelToSqlConverterDMTest {
         .scan("EMP")
         .project(builder.alias(concatRexNode, "CR"))
         .build();
-    final String expectedSql = "SELECT CONCAT('foo', 'bar', 'true') AS \"CR\"\n" + "FROM " +
-        "\"scott\".\"EMP\"";
-    final String expectedPostgresSql = "SELECT CONCAT('foo', 'bar') AS \"CR\"\n" + "FROM " +
-        "\"scott\".\"EMP\"";
+    final String expectedSql = "SELECT CONCAT('foo', 'bar', 'true') AS \"CR\"\n"
+        + "FROM \"scott\".\"EMP\"";
+    final String expectedPostgresSql = "SELECT CONCAT('foo', 'bar') AS \"CR\"\n"
+        + "FROM \"scott\".\"EMP\"";
     assertThat(toSql(root, DatabaseProduct.CALCITE.getDialect()), isLinux(expectedSql));
     assertThat(toSql(root, DatabaseProduct.POSTGRESQL.getDialect()), isLinux(expectedPostgresSql));
   }


### PR DESCRIPTION
Resolving extra t in case of concat in postgres procedure which was coming due to extra boolean Operand added to differentiate between CONCAT Operator(||) and CONCAT Function.