### PR TITLE
RSFB-3495: Changes Snowflake SHA2 function from VARCHAR_2000 to VARBINARY

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -3290,7 +3290,7 @@ public abstract class SqlLibraryOperators {
       new SqlFunction(
           "SHA2",
           SqlKind.OTHER_FUNCTION,
-          ReturnTypes.VARCHAR_2000,
+          ReturnTypes.VARBINARY,
           null,
           OperandTypes.family(
               ImmutableList.of(SqlTypeFamily.STRING, SqlTypeFamily.INTEGER),


### PR DESCRIPTION
https://datametica.atlassian.net/browse/RSFB-3495