### PR TITLE
Nirnay.patil/raven/rmsss 204/support for patindex

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/dialect/SparkSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/SparkSqlDialect.java
@@ -220,7 +220,6 @@ public class SparkSqlDialect extends SqlDialect {
   private static final Map<String, String> UDF_MAP =
       new HashMap<String, String>() {{
         put("TO_HEX", "UDF_CHAR2HEX");
-        put("REGEXP_INSTR", "UDF_REGEXP_INSTR");
         put("REGEXP_REPLACE", "UDF_REGEXP_REPLACE");
         put("ROUND", "UDF_ROUND");
         put("STRTOK", "UDF_STRTOK");
@@ -879,7 +878,6 @@ public class SparkSqlDialect extends SqlDialect {
       }
       break;
     case "TO_HEX":
-    case "REGEXP_INSTR":
     case "STRTOK":
       unparseUDF(writer, call, leftPrec, rightPrec, UDF_MAP.get(call.getOperator().getName()));
       return;

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -3976,4 +3976,15 @@ public abstract class SqlLibraryOperators {
           null,
           OperandTypes.STRING,
           SqlFunctionCategory.SYSTEM);
+
+  @LibraryOperator(libraries = {SQL_SERVER})
+  public static final SqlFunction PATINDEX =
+      new SqlFunction(
+          "PATINDEX",
+          SqlKind.OTHER_FUNCTION,
+          ReturnTypes.INTEGER,
+          null,
+          OperandTypes.family(SqlTypeFamily.STRING,
+              SqlTypeFamily.STRING),
+          SqlFunctionCategory.STRING);
 }

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -3982,9 +3982,8 @@ public abstract class SqlLibraryOperators {
       new SqlFunction(
           "PATINDEX",
           SqlKind.OTHER_FUNCTION,
-          ReturnTypes.INTEGER,
+          ReturnTypes.INTEGER_NULLABLE,
           null,
-          OperandTypes.family(SqlTypeFamily.STRING,
-              SqlTypeFamily.STRING),
+          OperandTypes.STRING_STRING,
           SqlFunctionCategory.STRING);
 }

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
@@ -8994,7 +8994,7 @@ class RelToSqlConverterDMTest {
     assertThat(toSql(root, DatabaseProduct.BIG_QUERY.getDialect()), isLinux(expectedBqSql));
   }
 
-  @Test public void testForPantindexFunction() {
+  @Test public void testForPatindexFunction() {
     final RelBuilder builder = relBuilder();
     final RexNode regexplike =
         builder.call(SqlLibraryOperators.PATINDEX, builder.literal("%abc%"), builder.literal("abcdef"));

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
@@ -8994,6 +8994,22 @@ class RelToSqlConverterDMTest {
     assertThat(toSql(root, DatabaseProduct.BIG_QUERY.getDialect()), isLinux(expectedBqSql));
   }
 
+  @Test public void testForPantindexFunction() {
+    final RelBuilder builder = relBuilder();
+    final RexNode regexplike =
+        builder.call(SqlLibraryOperators.PATINDEX, builder.literal("%abc%"), builder.literal("abcdef"));
+    final RelNode root = builder
+        .scan("EMP")
+        .project(builder.alias(regexplike, "A"))
+        .build();
+
+    final String expectedBqSql = "SELECT PATINDEX('%abc%', "
+        + "'abcdef') A\n"
+        + "FROM scott.EMP";
+
+    assertThat(toSql(root, DatabaseProduct.SPARK.getDialect()), isLinux(expectedBqSql));
+  }
+
   @Test public void testForRegexpSimilarFunctionWithThirdArgumentAsM() {
     final RelBuilder builder = relBuilder();
     final RexNode regexpSimilar =

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
@@ -9003,11 +9003,11 @@ class RelToSqlConverterDMTest {
         .project(builder.alias(patindex, "A"))
         .build();
 
-    final String expectedBqSql = "SELECT PATINDEX('%abc%', "
+    final String expectedSql = "SELECT PATINDEX('%abc%', "
         + "'abcdef') A\n"
         + "FROM scott.EMP";
 
-    assertThat(toSql(root, DatabaseProduct.SPARK.getDialect()), isLinux(expectedBqSql));
+    assertThat(toSql(root, DatabaseProduct.SPARK.getDialect()), isLinux(expectedSql));
   }
 
   @Test public void testForRegexpSimilarFunctionWithThirdArgumentAsM() {

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
@@ -8996,11 +8996,11 @@ class RelToSqlConverterDMTest {
 
   @Test public void testForPatindexFunction() {
     final RelBuilder builder = relBuilder();
-    final RexNode regexplike =
+    final RexNode patindex =
         builder.call(SqlLibraryOperators.PATINDEX, builder.literal("%abc%"), builder.literal("abcdef"));
     final RelNode root = builder
         .scan("EMP")
-        .project(builder.alias(regexplike, "A"))
+        .project(builder.alias(patindex, "A"))
         .build();
 
     final String expectedBqSql = "SELECT PATINDEX('%abc%', "


### PR DESCRIPTION
removing UDF_REGEXP_INSTR from the UDF map as REGEXP_INSTR function is working in databricks