### PR TITLE
RSFB-4649 Refactor Calcite skip simplification mechanism to remove comment based signaling

### DIFF
--- a/core/src/main/java/org/apache/calcite/rex/RexNode.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexNode.java
@@ -48,6 +48,7 @@ public abstract class RexNode extends CommentNode {
 
   // Effectively final. Set in each sub-class constructor, and never re-set.
   protected @MonotonicNonNull String digest;
+  protected boolean skipSimplifier = false;
 
   public RexNode() {
     super();
@@ -94,6 +95,25 @@ public abstract class RexNode extends CommentNode {
    */
   public SqlKind getKind() {
     return SqlKind.OTHER;
+  }
+
+  /**
+   * Returns the skipSimplifier of node this is.
+   *
+   * @return Node kind, never null
+   */
+  public boolean getSkipSimplifier() {
+    return skipSimplifier;
+  }
+
+  /**
+   * Returns the RexNode with updated skipSimplifier flag value.
+   *
+   * @return this
+   */
+  public RexNode setSkipSimplifier(boolean skipSimplifier) {
+    this.skipSimplifier = skipSimplifier;
+    return this;
   }
 
   @Override public String toString() {

--- a/core/src/main/java/org/apache/calcite/rex/RexShuttle.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexShuttle.java
@@ -113,20 +113,13 @@ public class RexShuttle implements RexVisitor<RexNode> {
   @Override public RexNode visitCall(final RexCall call) {
     boolean[] update = {false};
     List<RexNode> clonedOperands = visitList(call.operands, update);
-    boolean skipSimplify = !call.getComment().isEmpty()
-        && "skip_simplify".equals(call.getComment().iterator().next().getComment());
     if (update[0]) {
       // REVIEW jvs 8-Mar-2005:  This doesn't take into account
       // the fact that a rewrite may have changed the result type.
       // To do that, we would need to take a RexBuilder and
       // watch out for special operators like CAST and NEW where
       // the type is embedded in the original call.
-      RexCall updatedCall = call.clone(call.getType(), clonedOperands);
-      if (skipSimplify) {
-        return updatedCall.copy(call.getComment());
-      } else {
-        return updatedCall;
-      }
+      return call.clone(call.getType(), clonedOperands).setSkipSimplifier(call.skipSimplifier);
     } else {
       return call;
     }

--- a/core/src/main/java/org/apache/calcite/rex/RexSimplify.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexSimplify.java
@@ -263,9 +263,7 @@ public class RexSimplify {
    * Verify adds an overhead that is only acceptable for a top-level call.
    */
   RexNode simplify(RexNode e, RexUnknownAs unknownAs) {
-    boolean skipSimplify = !e.getComment().isEmpty()
-        && "skip_simplify".equals(((Comment) e.getComment().iterator().next()).getComment());
-    if (skipSimplify) {
+    if (e.skipSimplifier) {
       return e;
     }
     if (STRONG.isNull(e)) {

--- a/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
+++ b/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
@@ -2077,13 +2077,7 @@ public class RelBuilder {
 
     // Simplify expressions.
     if (config.simplify()) {
-      nodeList.replaceAll(e -> {
-        boolean skipSimplify = e.getComment() != null
-            && !e.getComment().isEmpty()
-            && "skip_simplify".equals(
-            e.getComment().iterator().next().getComment());
-        return skipSimplify ? e : simplifier.simplifyPreservingType(e);
-      });
+      nodeList.replaceAll(e -> e.getSkipSimplifier() ? e : simplifier.simplifyPreservingType(e));
     }
 
     // Replace null names with generated aliases.
@@ -2408,8 +2402,9 @@ public class RelBuilder {
         comments.addAll(operand.getComment());
       });
       comments.addAll(call.getComment());
+      boolean skipSimplifier = call.getSkipSimplifier();
       if (i >= 0) {
-        exprList.set(i, call.getOperands().get(0).copy(comments));
+        exprList.set(i, call.getOperands().get(0).copy(comments).setSkipSimplifier(skipSimplifier));
       }
       NlsString value = (NlsString) ((RexLiteral) call.getOperands().get(1)).getValue();
       return castNonNull(value)

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
@@ -122,9 +122,6 @@ import org.apache.calcite.tools.Programs;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.tools.RuleSet;
 import org.apache.calcite.tools.RuleSets;
-import org.apache.calcite.util.AnchorType;
-import org.apache.calcite.util.Comment;
-import org.apache.calcite.util.CommentType;
 import org.apache.calcite.util.DateString;
 import org.apache.calcite.util.Holder;
 import org.apache.calcite.util.ImmutableBitSet;
@@ -150,7 +147,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
@@ -14715,14 +14711,8 @@ class RelToSqlConverterDMTest {
     RexNode castNode =
         rexBuilder.makeAbstractCast(typeFactory.createSqlType(SqlTypeName.DECIMAL, 18, 4),
             literalRex, false);
-    RexNode finalNode =  builder.alias(castNode, "test");
-    Set<Comment> commentList = new HashSet<>();
-    commentList.add(
-        new Comment(
-        "skip_simplify",
-        AnchorType.LEFT,
-        CommentType.SINGLE));
-    RexNode finalRex = finalNode.copy(commentList);
+    RexNode finalNode = builder.alias(castNode, "test");
+    RexNode finalRex = finalNode.copy(new HashSet<>()).setSkipSimplifier(true);
 
     RelNode relNode = builder
         .project(
@@ -14730,7 +14720,7 @@ class RelToSqlConverterDMTest {
             finalRex)
         .build();
 
-    final String expectedBiqQuery = "SELECT employee_id, -- skip_simplify\n "
+    final String expectedBiqQuery = "SELECT employee_id, "
         + "CAST(10 AS NUMERIC) AS test\nFROM foodmart.employee";
 
     assertThat(toSql(relNode, DatabaseProduct.BIG_QUERY.getDialect()), isLinux(expectedBiqQuery));


### PR DESCRIPTION
RSFB-4649 Refactor Calcite “skip simplification” mechanism to remove comment-based signaling