### PR TITLE
[RSFB-4842] Preserve comment positional context in Snowflake-to-BigQuery translation

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/CTEDefinationTrait.java
+++ b/core/src/main/java/org/apache/calcite/plan/CTEDefinationTrait.java
@@ -16,6 +16,11 @@
  */
 package org.apache.calcite.plan;
 
+import org.apache.calcite.util.Comment;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
 /**
  * CTEDefinationTrait is used to identify if a given rel has a CTE Definition.
  */
@@ -25,11 +30,22 @@ public class CTEDefinationTrait implements RelTrait {
   private final String cteName;
   /** Whether the CTE was declared with an explicit column list (e.g., {@code WITH cte(col1, col2) AS (...)}). */
   private final boolean hasExplicitColumns;
+  /**
+   * Comments captured around the CTE name in the source (e.g. {@code WITH /* c *​/ cte AS (...)}).
+   * They retain their injected UUID and are re-anchored onto the unparsed name identifier.
+   */
+  private final Set<Comment> comments;
 
   public CTEDefinationTrait(boolean isCTEDefination, String cteName, boolean hasExplicitColumns) {
+    this(isCTEDefination, cteName, hasExplicitColumns, new LinkedHashSet<>());
+  }
+
+  public CTEDefinationTrait(boolean isCTEDefination, String cteName, boolean hasExplicitColumns,
+      Set<Comment> comments) {
     this.isCTEDefination = isCTEDefination;
     this.cteName = cteName;
     this.hasExplicitColumns = hasExplicitColumns;
+    this.comments = comments == null ? new LinkedHashSet<>() : comments;
   }
 
   public boolean isCTEDefination() {
@@ -42,6 +58,10 @@ public class CTEDefinationTrait implements RelTrait {
 
   public String getCteName() {
     return this.cteName;
+  }
+
+  public Set<Comment> getComments() {
+    return this.comments;
   }
 
   @Override public RelTraitDef<CTEDefinationTrait> getTraitDef() {

--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/CTERelToSqlUtil.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/CTERelToSqlUtil.java
@@ -431,6 +431,9 @@ public class CTERelToSqlUtil {
         });
         SqlWithItem updatedItem =
             new SqlWithItem(SqlParserPos.ZERO, withItem.name, withItem.columnList, modifiedQuery);
+        // Preserve comments captured around the CTE name (e.g. a comment before the 2nd+ CTE);
+        // this rebuild only runs for non-first CTEs, otherwise their name comments are dropped.
+        updatedItem.setCommentList(withItem.getCommentList());
         modifiedList.add(updatedItem);
         names.add(name);
       } else {

--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/CTERelToSqlUtil.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/CTERelToSqlUtil.java
@@ -410,6 +410,13 @@ public class CTERelToSqlUtil {
     return new SqlWith(sqlWith.getParserPosition(), modifiedList, sqlWith.body);
   }
 
+  /**
+   * Rebuilds the WITH-item list, dropping redundant nested WITH items.
+   *
+   * <p>The rebuild only runs for non-first CTEs. When an item is rebuilt, the comments
+   * captured around its CTE name (e.g. a comment before the 2nd+ CTE) are copied onto the
+   * replacement {@link SqlWithItem}; otherwise those name comments would be dropped.
+   */
   private static SqlNodeList modifyWithItemList(SqlNodeList modeList) {
     List<String> names = new ArrayList<>();
     List<SqlNode> modifiedList = new ArrayList<>();
@@ -431,8 +438,6 @@ public class CTERelToSqlUtil {
         });
         SqlWithItem updatedItem =
             new SqlWithItem(SqlParserPos.ZERO, withItem.name, withItem.columnList, modifiedQuery);
-        // Preserve comments captured around the CTE name (e.g. a comment before the 2nd+ CTE);
-        // this rebuild only runs for non-first CTEs, otherwise their name comments are dropped.
         updatedItem.setCommentList(withItem.getCommentList());
         modifiedList.add(updatedItem);
         names.add(name);

--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
@@ -717,6 +717,14 @@ public class RelToSqlConverter extends SqlImplementor
           rehydrateNestedComments(e, ref);
           SqlNode sqlExpr = builder.context.toSql(null, ref);
           Set<Comment> projectionComments = SqlCommentUtil.getCommentsInMap(e, ref);
+          // Comments toSql already placed on the expression are IN-PLACE comments: a comment that
+          // sits between the expression and its alias in the source ("expr /* note */ AS a") is
+          // captured inline on the expression's RexNode and rendered here. Capture them now -- before
+          // the clone below (which does not copy the comment list) and before merging in the
+          // map-keyed projectionComments -- so the lift below can tell an in-place comment (keep on
+          // the expression, before the alias) from an after-alias comment (present only in the map,
+          // lift past the alias).
+          Set<Comment> inlineOnExpr = new LinkedHashSet<>(sqlExpr.getCommentList());
           if (!projectionComments.isEmpty()) {
             // AliasContext.field(ordinal) returns a SqlNode shared via ordinalMap, so a bare
             // INPUT_REF projection's SqlNode may also be embedded inside another projection (e.g. a
@@ -744,22 +752,34 @@ public class RelToSqlConverter extends SqlImplementor
           }
           addSelect(selectList, sqlExpr, e.getRowType());
 
-          // SqlAsOperator (the select-item wrapper) is what emits a node's comments. When addSelect
-          // wraps sqlExpr in a fresh AS, a LEADING (LEFT) comment on a bare inner call (e.g. a
-          // window-function OVER call, whose own unparse emits nothing) would be orphaned. Lift only
-          // the LEFT comments onto the AS select item so they render before the column; RIGHT
-          // (trailing) comments stay on the inner node to keep their in-place position.
+          // SqlAsOperator (the select-item wrapper) is what emits a node's comments at unparse:
+          // LEFT comments before the column body, RIGHT (trailing) comments after the alias. When
+          // addSelect wraps sqlExpr in a fresh AS, decide which of sqlExpr's comments belong on the
+          // wrapper:
+          //   - LEFT (leading) comments: lift, so they render before the whole column -- a leading
+          //     comment on a bare inner call whose own unparse emits nothing (e.g. a window-function
+          //     OVER call) would otherwise be orphaned.
+          //   - RIGHT (trailing) comments captured PAST the alias (present only in the map, never
+          //     inline on the expression): lift, so they render after the alias.
+          //   - RIGHT comments that are IN-PLACE on the expression (a comment between the expression
+          //     and AS, "expr /* note */ AS a", captured inline on the RexNode): keep on sqlExpr so
+          //     they stay before the alias.
           SqlNode selectItem = selectList.get(selectList.size() - 1);
-          if (selectItem != sqlExpr) {
-            Set<Comment> onExpr = sqlExpr.getCommentList();
-            Set<Comment> leftComments = new LinkedHashSet<>();
-            Set<Comment> remaining = new LinkedHashSet<>();
-            for (Comment comment : onExpr) {
-              (comment.getAnchorType() == AnchorType.LEFT ? leftComments : remaining).add(comment);
+          if (selectItem != sqlExpr && !projectionComments.isEmpty()) {
+            Set<Comment> toLift = new LinkedHashSet<>();
+            for (Comment comment : projectionComments) {
+              if (comment.getAnchorType() == AnchorType.LEFT || !inlineOnExpr.contains(comment)) {
+                toLift.add(comment);
+              }
             }
-            if (!leftComments.isEmpty()) {
+            if (!toLift.isEmpty()) {
+              // getCommentList() returns a copy, so remove the lifted comments and write the
+              // remainder back explicitly; otherwise sqlExpr would keep them and the comment would
+              // render in both places.
+              Set<Comment> remaining = sqlExpr.getCommentList();
+              remaining.removeAll(toLift);
               sqlExpr.setCommentList(remaining);
-              selectItem.updateCommentSet(leftComments);
+              selectItem.updateCommentSet(toLift);
             }
           }
         }

--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
@@ -114,6 +114,7 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.util.SqlShuttle;
 import org.apache.calcite.sql.validate.SqlModality;
 import org.apache.calcite.sql.validate.SqlValidatorUtil;
+import org.apache.calcite.util.Comment;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.Pair;
 import org.apache.calcite.util.Permutation;
@@ -662,6 +663,29 @@ public class RelToSqlConverter extends SqlImplementor
   }
 
   /**
+   * Re-hydrates comments that were captured on nested expression RexNodes during
+   * canonical building and routed into the {@link org.apache.calcite.plan.CommentTrait}
+   * map (the durable carrier) because the inline comment on a nested {@code RexCall}
+   * does not survive projection/simplification rebuilds. For each RexNode in the
+   * projection expression, comments mapped to exactly that node are copied back onto
+   * its live comment set so {@code toSql} places them on the corresponding nested
+   * SqlNode and the unparser renders them in place (e.g. a comment before a CASE
+   * THEN branch). A direct (non-fallback) map lookup is used so a comment is restored
+   * only onto the node it annotates, never smeared onto that node's operands.
+   */
+  private static void rehydrateNestedComments(RelNode rel, RexNode rex) {
+    Set<Comment> mapped = SqlCommentUtil.getDirectCommentsInMap(rel, rex);
+    if (!mapped.isEmpty()) {
+      rex.getComment().addAll(mapped);
+    }
+    if (rex instanceof RexCall) {
+      for (RexNode operand : ((RexCall) rex).operands) {
+        rehydrateNestedComments(rel, operand);
+      }
+    }
+  }
+
+  /**
    * Visits a Project; called by {@link #dispatch} via reflection.
    */
   public Result visit(Project e) {
@@ -683,6 +707,7 @@ public class RelToSqlConverter extends SqlImplementor
         final List<SqlNode> selectList = new ArrayList<>();
         List<String> pivotColumnAliases = extractAliasesFromPivot(x);
         for (RexNode ref : e.getProjects()) {
+          rehydrateNestedComments(e, ref);
           SqlNode sqlExpr = builder.context.toSql(null, ref);
           sqlExpr.updateCommentSet(SqlCommentUtil.getCommentsInMap(e, ref));
           RelDataTypeField targetField = e.getRowType().getFieldList().get(selectList.size());
@@ -1131,9 +1156,19 @@ public class RelToSqlConverter extends SqlImplementor
 
     final List<SqlNode> groupKeys = new ArrayList<>();
     for (int key : groupList) {
-      groupKeys.add(getGroupBySqlNode(builder, key));
-      groupKeys.get(groupKeys.size() - 1)
-          .updateCommentSet(SqlCommentUtil.getCommentsInMap(aggregate, key));
+      SqlNode groupByNode = getGroupBySqlNode(builder, key);
+      Set<Comment> groupByComments = SqlCommentUtil.getCommentsInMap(aggregate, key);
+      if (!groupByComments.isEmpty()) {
+        // getGroupBySqlNode may return the very SqlNode instance that the SELECT
+        // list reuses (e.g. when the aggregate's input is a Project that inlines the
+        // grouping expression, so field(key) yields a shared node). Attaching the
+        // comment to that shared node would render it in both the SELECT list and the
+        // GROUP BY clause. Clone first so the comment is anchored to a node that is
+        // exclusive to the GROUP BY clause.
+        groupByNode = groupByNode.clone(groupByNode.getParserPosition());
+        groupByNode.updateCommentSet(groupByComments);
+      }
+      groupKeys.add(groupByNode);
     }
 
     for (int key : sortedGroupList) {
@@ -2283,6 +2318,14 @@ public class RelToSqlConverter extends SqlImplementor
     } else {
       columnList = identifierList(new ArrayList<>());
     }
-    return new SqlWithItem(POS, withName, columnList, result.node);
+    SqlWithItem withItem = new SqlWithItem(POS, withName, columnList, result.node);
+    // Re-anchor the comments captured around the CTE name onto the SqlWithItem rather than
+    // the name identifier: the name node is reused as the body's CTE reference, so a comment
+    // there would render twice and be stripped by comment deduplication. The SqlWithItem
+    // occurs once (the WITH-clause definition) and its operator emits these around the name.
+    if (cteDefinationTrait.getComments() != null && !cteDefinationTrait.getComments().isEmpty()) {
+      withItem.setCommentList(cteDefinationTrait.getComments());
+    }
+    return withItem;
   }
 }

--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
@@ -114,6 +114,7 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.util.SqlShuttle;
 import org.apache.calcite.sql.validate.SqlModality;
 import org.apache.calcite.sql.validate.SqlValidatorUtil;
+import org.apache.calcite.util.AnchorType;
 import org.apache.calcite.util.Comment;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.Pair;
@@ -139,6 +140,7 @@ import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -741,6 +743,25 @@ public class RelToSqlConverter extends SqlImplementor
             sqlExpr = new SqlIdentifier(pivotColumnAliases.get(index), SqlParserPos.ZERO);
           }
           addSelect(selectList, sqlExpr, e.getRowType());
+
+          // SqlAsOperator (the select-item wrapper) is what emits a node's comments. When addSelect
+          // wraps sqlExpr in a fresh AS, a LEADING (LEFT) comment on a bare inner call (e.g. a
+          // window-function OVER call, whose own unparse emits nothing) would be orphaned. Lift only
+          // the LEFT comments onto the AS select item so they render before the column; RIGHT
+          // (trailing) comments stay on the inner node to keep their in-place position.
+          SqlNode selectItem = selectList.get(selectList.size() - 1);
+          if (selectItem != sqlExpr) {
+            Set<Comment> onExpr = sqlExpr.getCommentList();
+            Set<Comment> leftComments = new LinkedHashSet<>();
+            Set<Comment> remaining = new LinkedHashSet<>();
+            for (Comment comment : onExpr) {
+              (comment.getAnchorType() == AnchorType.LEFT ? leftComments : remaining).add(comment);
+            }
+            if (!leftComments.isEmpty()) {
+              sqlExpr.setCommentList(remaining);
+              selectItem.updateCommentSet(leftComments);
+            }
+          }
         }
 
         builder.setSelect(new SqlNodeList(selectList, POS));

--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
@@ -683,12 +683,14 @@ public class RelToSqlConverter extends SqlImplementor
    * THEN branch). A direct (non-fallback) map lookup is used so a comment is restored
    * only onto the node it annotates, never smeared onto that node's operands.
    *
-   * <p>Comments are re-hydrated only onto nested expression ({@link RexCall}) nodes. A comment
-   * keyed by a bare {@link RexInputRef} is a column-level comment owned by its top-level
-   * projection (applied via {@code getCommentsInMap} at the projection site); applying it to a
-   * nested RexInputRef occurrence would smear the same comment onto every re-use of that
-   * aggregate/column output (e.g. a GROUP BY aggregate referenced again inside a later
-   * projection's expression).
+   * <p>Comments are re-hydrated onto nested expression ({@link RexCall}) nodes and onto nested
+   * leaf operands that are not bare column references (e.g. a literal on a CASE THEN branch,
+   * which {@code toSql} then renders before its branch value). A comment keyed by a bare
+   * {@link RexInputRef} is a column-level comment owned by its top-level projection (applied via
+   * {@code getCommentsInMap} at the projection site); applying it to a nested RexInputRef
+   * occurrence would smear the same comment onto every re-use of that aggregate/column output
+   * (e.g. a GROUP BY aggregate referenced again inside a later projection's expression), so such
+   * bare column references are skipped.
    */
   private static void rehydrateNestedComments(RelNode rel, RexNode rex) {
     if (rex instanceof RexCall) {
@@ -697,6 +699,12 @@ public class RelToSqlConverter extends SqlImplementor
         rex.getComment().addAll(mapped);
       }
       for (RexNode operand : ((RexCall) rex).operands) {
+        if (!(operand instanceof RexCall) && !(operand instanceof RexInputRef)) {
+          Set<Comment> operandMapped = SqlCommentUtil.getDirectCommentsInMap(rel, operand);
+          if (!operandMapped.isEmpty()) {
+            operand.getComment().addAll(operandMapped);
+          }
+        }
         rehydrateNestedComments(rel, operand);
       }
     }

--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
@@ -674,11 +674,16 @@ public class RelToSqlConverter extends SqlImplementor
    * only onto the node it annotates, never smeared onto that node's operands.
    */
   private static void rehydrateNestedComments(RelNode rel, RexNode rex) {
-    Set<Comment> mapped = SqlCommentUtil.getDirectCommentsInMap(rel, rex);
-    if (!mapped.isEmpty()) {
-      rex.getComment().addAll(mapped);
-    }
+    // Only re-hydrate comments onto nested expression (RexCall) nodes. A comment keyed by a bare
+    // RexInputRef is a column-level comment owned by its top-level projection (applied via
+    // getCommentsInMap at the projection site); applying it to a nested RexInputRef occurrence would
+    // smear the same comment onto every re-use of that aggregate/column output (e.g. a GROUP BY
+    // aggregate referenced again inside a later projection's expression).
     if (rex instanceof RexCall) {
+      Set<Comment> mapped = SqlCommentUtil.getDirectCommentsInMap(rel, rex);
+      if (!mapped.isEmpty()) {
+        rex.getComment().addAll(mapped);
+      }
       for (RexNode operand : ((RexCall) rex).operands) {
         rehydrateNestedComments(rel, operand);
       }
@@ -709,7 +714,18 @@ public class RelToSqlConverter extends SqlImplementor
         for (RexNode ref : e.getProjects()) {
           rehydrateNestedComments(e, ref);
           SqlNode sqlExpr = builder.context.toSql(null, ref);
-          sqlExpr.updateCommentSet(SqlCommentUtil.getCommentsInMap(e, ref));
+          Set<Comment> projectionComments = SqlCommentUtil.getCommentsInMap(e, ref);
+          if (!projectionComments.isEmpty()) {
+            // AliasContext.field(ordinal) returns a SqlNode shared via ordinalMap, so a bare
+            // INPUT_REF projection's SqlNode may also be embedded inside another projection (e.g. a
+            // reused aggregate output inside a COALESCE/NULLIF). Mutating that shared node with this
+            // select item's comment would smear the comment onto every reuse. Attach to a private
+            // clone so the comment renders only on this column.
+            if (ref instanceof RexInputRef) {
+              sqlExpr = sqlExpr.clone(sqlExpr.getParserPosition());
+            }
+            sqlExpr.updateCommentSet(projectionComments);
+          }
           RelDataTypeField targetField = e.getRowType().getFieldList().get(selectList.size());
 
           if (SqlKind.SINGLE_VALUE == sqlExpr.getKind()) {

--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
@@ -2323,7 +2323,7 @@ public class RelToSqlConverter extends SqlImplementor
     // the name identifier: the name node is reused as the body's CTE reference, so a comment
     // there would render twice and be stripped by comment deduplication. The SqlWithItem
     // occurs once (the WITH-clause definition) and its operator emits these around the name.
-    if (cteDefinationTrait.getComments() != null && !cteDefinationTrait.getComments().isEmpty()) {
+    if (!cteDefinationTrait.getComments().isEmpty()) {
       withItem.setCommentList(cteDefinationTrait.getComments());
     }
     return withItem;

--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
@@ -674,13 +674,15 @@ public class RelToSqlConverter extends SqlImplementor
    * SqlNode and the unparser renders them in place (e.g. a comment before a CASE
    * THEN branch). A direct (non-fallback) map lookup is used so a comment is restored
    * only onto the node it annotates, never smeared onto that node's operands.
+   *
+   * <p>Comments are re-hydrated only onto nested expression ({@link RexCall}) nodes. A comment
+   * keyed by a bare {@link RexInputRef} is a column-level comment owned by its top-level
+   * projection (applied via {@code getCommentsInMap} at the projection site); applying it to a
+   * nested RexInputRef occurrence would smear the same comment onto every re-use of that
+   * aggregate/column output (e.g. a GROUP BY aggregate referenced again inside a later
+   * projection's expression).
    */
   private static void rehydrateNestedComments(RelNode rel, RexNode rex) {
-    // Only re-hydrate comments onto nested expression (RexCall) nodes. A comment keyed by a bare
-    // RexInputRef is a column-level comment owned by its top-level projection (applied via
-    // getCommentsInMap at the projection site); applying it to a nested RexInputRef occurrence would
-    // smear the same comment onto every re-use of that aggregate/column output (e.g. a GROUP BY
-    // aggregate referenced again inside a later projection's expression).
     if (rex instanceof RexCall) {
       Set<Comment> mapped = SqlCommentUtil.getDirectCommentsInMap(rel, rex);
       if (!mapped.isEmpty()) {
@@ -694,6 +696,36 @@ public class RelToSqlConverter extends SqlImplementor
 
   /**
    * Visits a Project; called by {@link #dispatch} via reflection.
+   *
+   * <p>Comment handling for each projection expression:
+   *
+   * <ul>
+   * <li><b>In-place comments.</b> Comments that {@code toSql} already placed on the expression are
+   * IN-PLACE comments: a comment that sits between the expression and its alias in the source
+   * ({@code "expr /* note *&#47; AS a"}) is captured inline on the expression's RexNode and
+   * rendered there. They are captured (into {@code inlineOnExpr}) before the clone below (which
+   * does not copy the comment list) and before merging in the map-keyed projection comments, so
+   * the lift step can tell an in-place comment (keep on the expression, before the alias) from an
+   * after-alias comment (present only in the map, lift past the alias).
+   *
+   * <li><b>Shared bare INPUT_REF nodes.</b> {@code AliasContext.field(ordinal)} returns a SqlNode
+   * shared via {@code ordinalMap}, so a bare INPUT_REF projection's SqlNode may also be embedded
+   * inside another projection (e.g. a reused aggregate output inside a COALESCE/NULLIF). Mutating
+   * that shared node with this select item's comment would smear the comment onto every reuse, so
+   * the comment is attached to a private clone instead.
+   *
+   * <li><b>Lifting onto the AS wrapper.</b> {@code SqlAsOperator} (the select-item wrapper) is what
+   * emits a node's comments at unparse: LEFT comments before the column body, RIGHT (trailing)
+   * comments after the alias. When {@code addSelect} wraps the expression in a fresh AS, the
+   * comments that belong on the wrapper are lifted: LEFT (leading) comments — so a leading comment
+   * on a bare inner call whose own unparse emits nothing (e.g. a window-function OVER call) is not
+   * orphaned; and RIGHT (trailing) comments captured PAST the alias (present only in the map, never
+   * inline on the expression) — so they render after the alias. RIGHT comments that are IN-PLACE on
+   * the expression are kept on the expression so they stay before the alias. Because
+   * {@code getCommentList()} returns a copy, the lifted comments are removed and the remainder
+   * written back explicitly, otherwise the expression would keep them and the comment would render
+   * in both places.
+   * </ul>
    */
   public Result visit(Project e) {
     UnpivotRelToSqlUtil unpivotRelToSqlUtil = new UnpivotRelToSqlUtil();
@@ -717,20 +749,8 @@ public class RelToSqlConverter extends SqlImplementor
           rehydrateNestedComments(e, ref);
           SqlNode sqlExpr = builder.context.toSql(null, ref);
           Set<Comment> projectionComments = SqlCommentUtil.getCommentsInMap(e, ref);
-          // Comments toSql already placed on the expression are IN-PLACE comments: a comment that
-          // sits between the expression and its alias in the source ("expr /* note */ AS a") is
-          // captured inline on the expression's RexNode and rendered here. Capture them now -- before
-          // the clone below (which does not copy the comment list) and before merging in the
-          // map-keyed projectionComments -- so the lift below can tell an in-place comment (keep on
-          // the expression, before the alias) from an after-alias comment (present only in the map,
-          // lift past the alias).
           Set<Comment> inlineOnExpr = new LinkedHashSet<>(sqlExpr.getCommentList());
           if (!projectionComments.isEmpty()) {
-            // AliasContext.field(ordinal) returns a SqlNode shared via ordinalMap, so a bare
-            // INPUT_REF projection's SqlNode may also be embedded inside another projection (e.g. a
-            // reused aggregate output inside a COALESCE/NULLIF). Mutating that shared node with this
-            // select item's comment would smear the comment onto every reuse. Attach to a private
-            // clone so the comment renders only on this column.
             if (ref instanceof RexInputRef) {
               sqlExpr = sqlExpr.clone(sqlExpr.getParserPosition());
             }
@@ -752,18 +772,6 @@ public class RelToSqlConverter extends SqlImplementor
           }
           addSelect(selectList, sqlExpr, e.getRowType());
 
-          // SqlAsOperator (the select-item wrapper) is what emits a node's comments at unparse:
-          // LEFT comments before the column body, RIGHT (trailing) comments after the alias. When
-          // addSelect wraps sqlExpr in a fresh AS, decide which of sqlExpr's comments belong on the
-          // wrapper:
-          //   - LEFT (leading) comments: lift, so they render before the whole column -- a leading
-          //     comment on a bare inner call whose own unparse emits nothing (e.g. a window-function
-          //     OVER call) would otherwise be orphaned.
-          //   - RIGHT (trailing) comments captured PAST the alias (present only in the map, never
-          //     inline on the expression): lift, so they render after the alias.
-          //   - RIGHT comments that are IN-PLACE on the expression (a comment between the expression
-          //     and AS, "expr /* note */ AS a", captured inline on the RexNode): keep on sqlExpr so
-          //     they stay before the alias.
           SqlNode selectItem = selectList.get(selectList.size() - 1);
           if (selectItem != sqlExpr && !projectionComments.isEmpty()) {
             Set<Comment> toLift = new LinkedHashSet<>();
@@ -773,9 +781,6 @@ public class RelToSqlConverter extends SqlImplementor
               }
             }
             if (!toLift.isEmpty()) {
-              // getCommentList() returns a copy, so remove the lifted comments and write the
-              // remainder back explicitly; otherwise sqlExpr would keep them and the comment would
-              // render in both places.
               Set<Comment> remaining = sqlExpr.getCommentList();
               remaining.removeAll(toLift);
               sqlExpr.setCommentList(remaining);
@@ -1202,6 +1207,13 @@ public class RelToSqlConverter extends SqlImplementor
    * SELECT will be identical; if the GROUP BY list contains GROUPING SETS,
    * CUBE or ROLLUP, the SELECT clause will contain the distinct leaf
    * expressions.
+   *
+   * <p>When a grouping key carries comments, the GROUP BY SqlNode is cloned before the comments
+   * are attached. {@code getGroupBySqlNode} may return the very SqlNode instance that the SELECT
+   * list reuses (e.g. when the aggregate's input is a Project that inlines the grouping expression,
+   * so {@code field(key)} yields a shared node); attaching the comment to that shared node would
+   * render it in both the SELECT list and the GROUP BY clause. Cloning anchors the comment to a
+   * node that is exclusive to the GROUP BY clause.
    */
   private List<SqlNode> generateGroupList(Builder builder,
       List<SqlNode> selectList, Aggregate aggregate, List<Integer> groupList) {
@@ -1216,12 +1228,6 @@ public class RelToSqlConverter extends SqlImplementor
       SqlNode groupByNode = getGroupBySqlNode(builder, key);
       Set<Comment> groupByComments = SqlCommentUtil.getCommentsInMap(aggregate, key);
       if (!groupByComments.isEmpty()) {
-        // getGroupBySqlNode may return the very SqlNode instance that the SELECT
-        // list reuses (e.g. when the aggregate's input is a Project that inlines the
-        // grouping expression, so field(key) yields a shared node). Attaching the
-        // comment to that shared node would render it in both the SELECT list and the
-        // GROUP BY clause. Clone first so the comment is anchored to a node that is
-        // exclusive to the GROUP BY clause.
         groupByNode = groupByNode.clone(groupByNode.getParserPosition());
         groupByNode.updateCommentSet(groupByComments);
       }
@@ -2362,6 +2368,11 @@ public class RelToSqlConverter extends SqlImplementor
   /**
    * Creates a SqlWithItem (CTE) with the given CTE definition trait and result.
    *
+   * <p>Comments captured around the CTE name are re-anchored onto the {@link SqlWithItem}
+   * rather than the name identifier: the name node is reused as the body's CTE reference, so a
+   * comment there would render twice and be stripped by comment deduplication. The SqlWithItem
+   * occurs once (the WITH-clause definition) and its operator emits these comments around the name.
+   *
    * @param cteDefinationTrait - The CTE definition trait containing the CTE name
    * @param result - The relational algebra result node
    * @return SqlWithItem - The constructed SqlWithItem for the CTE
@@ -2376,10 +2387,6 @@ public class RelToSqlConverter extends SqlImplementor
       columnList = identifierList(new ArrayList<>());
     }
     SqlWithItem withItem = new SqlWithItem(POS, withName, columnList, result.node);
-    // Re-anchor the comments captured around the CTE name onto the SqlWithItem rather than
-    // the name identifier: the name node is reused as the body's CTE reference, so a comment
-    // there would render twice and be stripped by comment deduplication. The SqlWithItem
-    // occurs once (the WITH-clause definition) and its operator emits these around the name.
     if (!cteDefinationTrait.getComments().isEmpty()) {
       withItem.setCommentList(cteDefinationTrait.getComments());
     }

--- a/core/src/main/java/org/apache/calcite/rex/RexSubQuery.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexSubQuery.java
@@ -34,7 +34,7 @@ import com.google.common.collect.ImmutableList;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -189,11 +189,11 @@ public class RexSubQuery extends RexCall {
 
   @Override public RexSubQuery clone(RelDataType type, List<RexNode> operands) {
     return new RexSubQuery(type, getOperator(),
-        ImmutableList.copyOf(operands), rel, new HashSet<>(getComment()));
+        ImmutableList.copyOf(operands), rel, new LinkedHashSet<>(getComment()));
   }
 
   public RexSubQuery clone(RelNode rel) {
-    return new RexSubQuery(type, getOperator(), operands, rel, new HashSet<>(getComment()));
+    return new RexSubQuery(type, getOperator(), operands, rel, new LinkedHashSet<>(getComment()));
   }
 
   @Override public boolean equals(@Nullable Object obj) {

--- a/core/src/main/java/org/apache/calcite/rex/RexSubQuery.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexSubQuery.java
@@ -34,6 +34,7 @@ import com.google.common.collect.ImmutableList;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -188,11 +189,11 @@ public class RexSubQuery extends RexCall {
 
   @Override public RexSubQuery clone(RelDataType type, List<RexNode> operands) {
     return new RexSubQuery(type, getOperator(),
-        ImmutableList.copyOf(operands), rel);
+        ImmutableList.copyOf(operands), rel, new HashSet<>(getComment()));
   }
 
   public RexSubQuery clone(RelNode rel) {
-    return new RexSubQuery(type, getOperator(), operands, rel);
+    return new RexSubQuery(type, getOperator(), operands, rel, new HashSet<>(getComment()));
   }
 
   @Override public boolean equals(@Nullable Object obj) {

--- a/core/src/main/java/org/apache/calcite/util/SqlCommentUtil.java
+++ b/core/src/main/java/org/apache/calcite/util/SqlCommentUtil.java
@@ -56,6 +56,21 @@ public final class SqlCommentUtil {
     }
   }
 
+  /**
+   * Retrieves comments mapped to exactly this RexNode (structural/digest match),
+   * with no operand-contains fallback. Used to re-hydrate comments onto the
+   * precise nested RexNode they annotate, so a comment keyed to an inner
+   * expression is not also smeared onto the inner expression's own operands.
+   */
+  public static Set<Comment> getDirectCommentsInMap(RelNode relNode, RexNode rex) {
+    CommentTrait commentTrait = relNode.getTraitSet().getTrait(CommentTraitDef.INSTANCE);
+    if (commentTrait == null) {
+      return Collections.emptySet();
+    }
+    Set<Comment> result = commentTrait.getCommentsMap().get(rex);
+    return result == null ? Collections.emptySet() : result;
+  }
+
   /** Retrieves comments for a given RexNode from a RelNode’s CommentTrait map. */
   public static Set<Comment> getCommentsInMap(RelNode relNode, RexNode rex) {
     CommentTrait commentTrait = relNode.getTraitSet().getTrait(CommentTraitDef.INSTANCE);

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
@@ -123,6 +123,9 @@ import org.apache.calcite.tools.Programs;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.tools.RuleSet;
 import org.apache.calcite.tools.RuleSets;
+import org.apache.calcite.util.AnchorType;
+import org.apache.calcite.util.Comment;
+import org.apache.calcite.util.CommentType;
 import org.apache.calcite.util.DateString;
 import org.apache.calcite.util.Holder;
 import org.apache.calcite.util.ImmutableBitSet;
@@ -12269,6 +12272,46 @@ class RelToSqlConverterDMTest {
     final String expectedSql = "WITH RUNDATE AS (SELECT first_name, last_name, birth_date\nFROM "
                                 + "foodmart.employee\nGROUP BY first_name, last_name, birth_date)"
                                 + " (SELECT first_name AS FNAME\nFROM RUNDATE)";
+    assertThat(actualSql, isLinux(expectedSql));
+  }
+
+  @Test public void testCTEWithTraitsRetainsNameComment() {
+    final RelBuilder builder = foodmartRelBuilder();
+
+    final RelNode rundate = builder.scan("employee")
+        .project(builder.field("first_name"), builder.field("last_name"),
+            builder.field("birth_date"))
+        .aggregate(builder.groupKey(0, 1, 2))
+        .build();
+
+    // CTE definition trait carrying a comment captured around the CTE name.
+    final Comment nameComment = new Comment("my cte", AnchorType.LEFT, CommentType.MULTIPLE);
+    final CTEDefinationTrait cteTrait =
+        new CTEDefinationTrait(true, "RUNDATE", false,
+            new java.util.LinkedHashSet<>(Collections.singletonList(nameComment)));
+    final RelTraitSet cteRelTraitSet = rundate.getTraitSet().plus(cteTrait);
+    final RelNode cteRelNodeWithRelTrait = rundate.copy(cteRelTraitSet, rundate.getInputs());
+
+    final RelNode innerSelect = builder
+        .push(cteRelNodeWithRelTrait)
+        .project(
+            builder.alias(
+                builder.field("first_name"),
+                "FNAME")).build();
+
+    final CTEScopeTrait cteScopeTrait = new CTEScopeTrait(true);
+    final RelTraitSet cteScopeRelTraitSet = innerSelect.getTraitSet().plus(cteScopeTrait);
+    final RelNode cteScopeRelNodeWithRelTrait =
+        innerSelect.copy(cteScopeRelTraitSet, innerSelect.getInputs());
+
+    final String actualSql =
+        toSql(cteScopeRelNodeWithRelTrait, DatabaseProduct.BIG_QUERY.getDialect());
+
+    // The comment captured around the CTE name renders before the name at the WITH-clause
+    // definition only; the body reference (which reuses the name node) is left untouched.
+    final String expectedSql = "WITH /* my cte */ RUNDATE AS (SELECT first_name, last_name, birth_date"
+        + "\nFROM foodmart.employee\nGROUP BY first_name, last_name, birth_date)"
+        + " (SELECT first_name AS FNAME\nFROM RUNDATE)";
     assertThat(actualSql, isLinux(expectedSql));
   }
 

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
@@ -12508,6 +12508,8 @@ class RelToSqlConverterDMTest {
 
     assertThat(clonedViaOperands.getComment().contains(comment), is(true));
     assertThat(clonedViaRel.getComment().contains(comment), is(true));
+  }
+
   /*FROM TMP A UNPIVOT(...) must produce
     FROM TMP AS A UNPIVOT(...) not FROM (SELECT ...) AS A UNPIVOT(...)*/
   @Test public void testCTASWithCTEAndAliasedReferenceInUnpivot() {

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
@@ -12295,6 +12295,11 @@ class RelToSqlConverterDMTest {
     assertThat(actualSql, isLinux(expectedSql));
   }
 
+  /**
+   * Verifies that a comment captured around a CTE name (carried on the {@link CTEDefinationTrait})
+   * renders before the name at the WITH-clause definition only; the body reference, which reuses
+   * the name node, is left untouched.
+   */
   @Test public void testCTEWithTraitsRetainsNameComment() {
     final RelBuilder builder = foodmartRelBuilder();
 
@@ -12304,7 +12309,6 @@ class RelToSqlConverterDMTest {
         .aggregate(builder.groupKey(0, 1, 2))
         .build();
 
-    // CTE definition trait carrying a comment captured around the CTE name.
     final Comment nameComment = new Comment("my cte", AnchorType.LEFT, CommentType.MULTIPLE);
     final CTEDefinationTrait cteTrait =
         new CTEDefinationTrait(true, "RUNDATE", false,
@@ -12327,8 +12331,6 @@ class RelToSqlConverterDMTest {
     final String actualSql =
         toSql(cteScopeRelNodeWithRelTrait, DatabaseProduct.BIG_QUERY.getDialect());
 
-    // The comment captured around the CTE name renders before the name at the WITH-clause
-    // definition only; the body reference (which reuses the name node) is left untouched.
     final String expectedSql = "WITH /* my cte */ RUNDATE AS (SELECT first_name, last_name, birth_date"
         + "\nFROM foodmart.employee\nGROUP BY first_name, last_name, birth_date)"
         + " (SELECT first_name AS FNAME\nFROM RUNDATE)";
@@ -12344,6 +12346,11 @@ class RelToSqlConverterDMTest {
     return count;
   }
 
+  /**
+   * The comment keyed to the top-level projected expression is reachable both via
+   * {@code rehydrateNestedComments} and via the {@code getCommentsInMap} fallback, but the SqlNode
+   * comment set (a LinkedHashSet keyed on comment UUID) collapses the duplicate, so it renders once.
+   */
   @Test public void testTopLevelProjectedExpressionCommentRendersOnce() {
     final RelBuilder builder = foodmartRelBuilder();
     builder.scan("employee");
@@ -12360,15 +12367,16 @@ class RelToSqlConverterDMTest {
         rel.copy(rel.getTraitSet().plus(commentTrait), rel.getInputs());
 
     final String actualSql = toSql(relWithComment, DatabaseProduct.BIG_QUERY.getDialect());
-    // The comment keyed to the top-level projected expression is reachable both via
-    // rehydrateNestedComments and via the getCommentsInMap fallback, but the SqlNode comment
-    // set (LinkedHashSet keyed on comment UUID) collapses the duplicate, so it renders once.
     final String expectedSql = "SELECT /* top level */ salary + salary AS `$f0`"
         + "\nFROM foodmart.employee";
     assertThat(actualSql, isLinux(expectedSql));
     assertThat(countOccurrences(actualSql, "/* top level */"), is(1));
   }
 
+  /**
+   * The comment is anchored to a nested operand (the THEN value), not the top-level CASE, so
+   * {@code rehydrateNestedComments} must walk into the RexCall operands and re-attach it there.
+   */
   @Test public void testRehydrateNestedCaseThenComment() {
     final RelBuilder builder = foodmartRelBuilder();
     builder.scan("employee");
@@ -12381,8 +12389,6 @@ class RelToSqlConverterDMTest {
         builder.call(SqlStdOperatorTable.CASE, cond, thenVal, elseVal);
     final RelNode rel = builder.project(caseExpr).build();
 
-    // Comment anchored to a nested operand (the THEN value), not the top-level CASE.
-    // rehydrateNestedComments must walk into the RexCall operands and re-attach it there.
     final Comment comment = new Comment("then branch", AnchorType.LEFT, CommentType.MULTIPLE);
     final Map<RexNode, java.util.Set<Comment>> commentMap = new HashMap<>();
     commentMap.put(thenVal, new java.util.LinkedHashSet<>(Collections.singletonList(comment)));
@@ -12397,6 +12403,11 @@ class RelToSqlConverterDMTest {
     assertThat(countOccurrences(actualSql, "/* then branch */"), is(1));
   }
 
+  /**
+   * The comment is keyed to the grouping input ref. {@code getGroupBySqlNode} may hand back the
+   * very SqlNode the SELECT list reuses; the {@code generateGroupList} clone fix must keep the
+   * comment on a node exclusive to GROUP BY so it is not duplicated into SELECT.
+   */
   @Test public void testGroupByCommentNotDuplicatedInSelect() {
     final RelBuilder builder = foodmartRelBuilder();
     final RelNode agg = builder.scan("employee")
@@ -12404,9 +12415,6 @@ class RelToSqlConverterDMTest {
         .aggregate(builder.groupKey(0))
         .build();
 
-    // Comment keyed to the grouping input ref. getGroupBySqlNode may hand back the very
-    // SqlNode the SELECT list reuses; the generateGroupList clone fix must keep the comment
-    // on a node exclusive to GROUP BY so it is not duplicated into SELECT.
     final Comment comment = new Comment("group key", AnchorType.LEFT, CommentType.MULTIPLE);
     final Map<RexNode, java.util.Set<Comment>> commentMap = new HashMap<>();
     commentMap.put(new RexInputRef(0, agg.getRowType().getFieldList().get(0).getType()),
@@ -12422,6 +12430,11 @@ class RelToSqlConverterDMTest {
     assertThat(countOccurrences(actualSql, "/* group key */"), is(1));
   }
 
+  /**
+   * A comment captured around the 2nd CTE name must survive {@code modifyWithItemList}, which
+   * rebuilds every non-first CTE item; without the explicit comment copy this comment would be
+   * dropped.
+   */
   @Test public void testModifyWithItemListRetainsSecondCteNameComment() {
     final SqlNodeList selectList =
         new SqlNodeList(Collections.singletonList(new SqlIdentifier("c", SqlParserPos.ZERO)),
@@ -12437,8 +12450,6 @@ class RelToSqlConverterDMTest {
         new SqlWithItem(SqlParserPos.ZERO, new SqlIdentifier("A", SqlParserPos.ZERO), null, query1);
     final SqlWithItem item2 =
         new SqlWithItem(SqlParserPos.ZERO, new SqlIdentifier("B", SqlParserPos.ZERO), null, query2);
-    // Comment captured around the 2nd CTE name. modifyWithItemList rebuilds every non-first
-    // CTE item, so without the explicit comment copy this comment would be dropped.
     final Comment comment = new Comment("second cte", AnchorType.LEFT, CommentType.MULTIPLE);
     item2.setCommentList(new java.util.LinkedHashSet<>(Collections.singletonList(comment)));
 

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
@@ -80,8 +80,8 @@ import org.apache.calcite.sql.SqlDialect.Context;
 import org.apache.calcite.sql.SqlDialect.DatabaseProduct;
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
-import org.apache.calcite.sql.SqlIntervalQualifier;
 import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlIntervalQualifier;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
@@ -12412,17 +12412,17 @@ class RelToSqlConverterDMTest {
     final SqlNodeList selectList =
         new SqlNodeList(Collections.singletonList(new SqlIdentifier("c", SqlParserPos.ZERO)),
             SqlParserPos.ZERO);
-    final SqlSelect query1 = new SqlSelect(SqlParserPos.ZERO, null, selectList,
-        null, null, null, null, null, null, null, null, null, null);
-    final SqlSelect query2 = new SqlSelect(SqlParserPos.ZERO, null, selectList,
-        null, null, null, null, null, null, null, null, null, null);
-    final SqlSelect body = new SqlSelect(SqlParserPos.ZERO, null, selectList,
-        null, null, null, null, null, null, null, null, null, null);
+    final SqlSelect query1 =
+        new SqlSelect(SqlParserPos.ZERO, null, selectList, null, null, null, null, null, null, null, null, null, null);
+    final SqlSelect query2 =
+        new SqlSelect(SqlParserPos.ZERO, null, selectList, null, null, null, null, null, null, null, null, null, null);
+    final SqlSelect body =
+        new SqlSelect(SqlParserPos.ZERO, null, selectList, null, null, null, null, null, null, null, null, null, null);
 
-    final SqlWithItem item1 = new SqlWithItem(SqlParserPos.ZERO,
-        new SqlIdentifier("A", SqlParserPos.ZERO), null, query1);
-    final SqlWithItem item2 = new SqlWithItem(SqlParserPos.ZERO,
-        new SqlIdentifier("B", SqlParserPos.ZERO), null, query2);
+    final SqlWithItem item1 =
+        new SqlWithItem(SqlParserPos.ZERO, new SqlIdentifier("A", SqlParserPos.ZERO), null, query1);
+    final SqlWithItem item2 =
+        new SqlWithItem(SqlParserPos.ZERO, new SqlIdentifier("B", SqlParserPos.ZERO), null, query2);
     // Comment captured around the 2nd CTE name. modifyWithItemList rebuilds every non-first
     // CTE item, so without the explicit comment copy this comment would be dropped.
     final Comment comment = new Comment("second cte", AnchorType.LEFT, CommentType.MULTIPLE);

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
@@ -21,6 +21,7 @@ import org.apache.calcite.avatica.util.TimeUnitRange;
 import org.apache.calcite.config.NullCollation;
 import org.apache.calcite.plan.CTEDefinationTrait;
 import org.apache.calcite.plan.CTEScopeTrait;
+import org.apache.calcite.plan.CommentTrait;
 import org.apache.calcite.plan.GroupByWithQualifyHavingRankRelTrait;
 import org.apache.calcite.plan.QualifyRelTrait;
 import org.apache.calcite.plan.QualifyRelTraitDef;
@@ -80,8 +81,13 @@ import org.apache.calcite.sql.SqlDialect.DatabaseProduct;
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.SqlIntervalQualifier;
+import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlSelect;
+import org.apache.calcite.sql.SqlWith;
+import org.apache.calcite.sql.SqlWithItem;
 import org.apache.calcite.sql.SqlWriterConfig;
 import org.apache.calcite.sql.dialect.CalciteSqlDialect;
 import org.apache.calcite.sql.dialect.HiveSqlDialect;
@@ -12313,6 +12319,140 @@ class RelToSqlConverterDMTest {
         + "\nFROM foodmart.employee\nGROUP BY first_name, last_name, birth_date)"
         + " (SELECT first_name AS FNAME\nFROM RUNDATE)";
     assertThat(actualSql, isLinux(expectedSql));
+  }
+
+  private static int countOccurrences(String haystack, String needle) {
+    int count = 0;
+    for (int idx = haystack.indexOf(needle); idx >= 0;
+        idx = haystack.indexOf(needle, idx + needle.length())) {
+      count++;
+    }
+    return count;
+  }
+
+  @Test public void testTopLevelProjectedExpressionCommentRendersOnce() {
+    final RelBuilder builder = foodmartRelBuilder();
+    builder.scan("employee");
+    final RexNode expr =
+        builder.call(SqlStdOperatorTable.PLUS, builder.field("salary"), builder.field("salary"));
+    final RelNode rel = builder.project(expr).build();
+
+    final Comment comment =
+        new Comment("top level", AnchorType.LEFT, CommentType.MULTIPLE);
+    final Map<RexNode, java.util.Set<Comment>> commentMap = new HashMap<>();
+    commentMap.put(expr, new java.util.LinkedHashSet<>(Collections.singletonList(comment)));
+    final CommentTrait commentTrait = new CommentTrait(commentMap, new java.util.LinkedHashSet<>());
+    final RelNode relWithComment =
+        rel.copy(rel.getTraitSet().plus(commentTrait), rel.getInputs());
+
+    final String actualSql = toSql(relWithComment, DatabaseProduct.BIG_QUERY.getDialect());
+    // The comment keyed to the top-level projected expression is reachable both via
+    // rehydrateNestedComments and via the getCommentsInMap fallback, but the SqlNode comment
+    // set (LinkedHashSet keyed on comment UUID) collapses the duplicate, so it renders once.
+    final String expectedSql = "SELECT /* top level */ salary + salary AS `$f0`"
+        + "\nFROM foodmart.employee";
+    assertThat(actualSql, isLinux(expectedSql));
+    assertThat(countOccurrences(actualSql, "/* top level */"), is(1));
+  }
+
+  @Test public void testRehydrateNestedCaseThenComment() {
+    final RelBuilder builder = foodmartRelBuilder();
+    builder.scan("employee");
+    final RexNode cond =
+        builder.call(SqlStdOperatorTable.GREATER_THAN, builder.field("salary"),
+            builder.literal(1000));
+    final RexNode thenVal = builder.literal(1);
+    final RexNode elseVal = builder.literal(0);
+    final RexNode caseExpr =
+        builder.call(SqlStdOperatorTable.CASE, cond, thenVal, elseVal);
+    final RelNode rel = builder.project(caseExpr).build();
+
+    // Comment anchored to a nested operand (the THEN value), not the top-level CASE.
+    // rehydrateNestedComments must walk into the RexCall operands and re-attach it there.
+    final Comment comment = new Comment("then branch", AnchorType.LEFT, CommentType.MULTIPLE);
+    final Map<RexNode, java.util.Set<Comment>> commentMap = new HashMap<>();
+    commentMap.put(thenVal, new java.util.LinkedHashSet<>(Collections.singletonList(comment)));
+    final CommentTrait commentTrait = new CommentTrait(commentMap, new java.util.LinkedHashSet<>());
+    final RelNode relWithComment =
+        rel.copy(rel.getTraitSet().plus(commentTrait), rel.getInputs());
+
+    final String actualSql = toSql(relWithComment, DatabaseProduct.BIG_QUERY.getDialect());
+    final String expectedSql = "SELECT CASE WHEN salary > 1000 THEN /* then branch */ 1 ELSE 0 END"
+        + " AS `$f0`\nFROM foodmart.employee";
+    assertThat(actualSql, isLinux(expectedSql));
+    assertThat(countOccurrences(actualSql, "/* then branch */"), is(1));
+  }
+
+  @Test public void testGroupByCommentNotDuplicatedInSelect() {
+    final RelBuilder builder = foodmartRelBuilder();
+    final RelNode agg = builder.scan("employee")
+        .project(builder.field("first_name"))
+        .aggregate(builder.groupKey(0))
+        .build();
+
+    // Comment keyed to the grouping input ref. getGroupBySqlNode may hand back the very
+    // SqlNode the SELECT list reuses; the generateGroupList clone fix must keep the comment
+    // on a node exclusive to GROUP BY so it is not duplicated into SELECT.
+    final Comment comment = new Comment("group key", AnchorType.LEFT, CommentType.MULTIPLE);
+    final Map<RexNode, java.util.Set<Comment>> commentMap = new HashMap<>();
+    commentMap.put(new RexInputRef(0, agg.getRowType().getFieldList().get(0).getType()),
+        new java.util.LinkedHashSet<>(Collections.singletonList(comment)));
+    final CommentTrait commentTrait = new CommentTrait(commentMap, new java.util.LinkedHashSet<>());
+    final RelNode relWithComment =
+        agg.copy(agg.getTraitSet().plus(commentTrait), agg.getInputs());
+
+    final String actualSql = toSql(relWithComment, DatabaseProduct.BIG_QUERY.getDialect());
+    final String expectedSql = "SELECT first_name\nFROM foodmart.employee"
+        + "\nGROUP BY /* group key */ first_name";
+    assertThat(actualSql, isLinux(expectedSql));
+    assertThat(countOccurrences(actualSql, "/* group key */"), is(1));
+  }
+
+  @Test public void testModifyWithItemListRetainsSecondCteNameComment() {
+    final SqlNodeList selectList =
+        new SqlNodeList(Collections.singletonList(new SqlIdentifier("c", SqlParserPos.ZERO)),
+            SqlParserPos.ZERO);
+    final SqlSelect query1 = new SqlSelect(SqlParserPos.ZERO, null, selectList,
+        null, null, null, null, null, null, null, null, null, null);
+    final SqlSelect query2 = new SqlSelect(SqlParserPos.ZERO, null, selectList,
+        null, null, null, null, null, null, null, null, null, null);
+    final SqlSelect body = new SqlSelect(SqlParserPos.ZERO, null, selectList,
+        null, null, null, null, null, null, null, null, null, null);
+
+    final SqlWithItem item1 = new SqlWithItem(SqlParserPos.ZERO,
+        new SqlIdentifier("A", SqlParserPos.ZERO), null, query1);
+    final SqlWithItem item2 = new SqlWithItem(SqlParserPos.ZERO,
+        new SqlIdentifier("B", SqlParserPos.ZERO), null, query2);
+    // Comment captured around the 2nd CTE name. modifyWithItemList rebuilds every non-first
+    // CTE item, so without the explicit comment copy this comment would be dropped.
+    final Comment comment = new Comment("second cte", AnchorType.LEFT, CommentType.MULTIPLE);
+    item2.setCommentList(new java.util.LinkedHashSet<>(Collections.singletonList(comment)));
+
+    final SqlNodeList withItems =
+        new SqlNodeList(Arrays.asList(item1, item2), SqlParserPos.ZERO);
+    final SqlWith with = new SqlWith(SqlParserPos.ZERO, withItems, body);
+
+    final SqlWith modified = CTERelToSqlUtil.modifyWithNode(with);
+    final SqlNodeList modifiedItems = (SqlNodeList) modified.getOperandList().get(0);
+    final SqlWithItem modifiedSecondItem = (SqlWithItem) modifiedItems.get(1);
+
+    assertThat(modifiedSecondItem.getCommentList().contains(comment), is(true));
+  }
+
+  @Test public void testRexSubQueryCloneRetainsComment() {
+    final RelBuilder builder = relBuilder();
+    final RelNode rel = builder.scan("EMP").build();
+    final RexSubQuery subQuery = RexSubQuery.exists(rel);
+
+    final Comment comment = new Comment("subquery", AnchorType.LEFT, CommentType.MULTIPLE);
+    subQuery.getComment().add(comment);
+
+    final RexSubQuery clonedViaOperands =
+        subQuery.clone(subQuery.getType(), subQuery.getOperands());
+    final RexSubQuery clonedViaRel = subQuery.clone(rel);
+
+    assertThat(clonedViaOperands.getComment().contains(comment), is(true));
+    assertThat(clonedViaRel.getComment().contains(comment), is(true));
   }
 
   @Test public void testGenerateUUID() {


### PR DESCRIPTION
## Jira
RSFB-4842 — SF_BQ : DML : Raven: Comments lose positional context during Snowflake-to-BigQuery translation

## Problem
Raven did partial comment preservation: comments survived but lost positional context — many detached from their SQL block and shifted to the top of the generated BigQuery query, and some were dropped.

## Changes
- **CTEDefinationTrait**: carry comments captured around the CTE name; re-anchor onto the `SqlWithItem` definition (rendered once, avoiding duplicate-then-stripped comments on the reused name reference).
- **CTERelToSqlUtil**: preserve name comments when rebuilding non-first CTEs.
- **RelToSqlConverter**: rehydrate nested-expression comments from the `CommentTrait` map back onto the precise `RexNode` (e.g. CASE THEN branch); clone the GROUP BY node before attaching comments so they aren't also rendered in the SELECT list.
- **SqlCommentUtil**: add `getDirectCommentsInMap` for exact-node lookup with no operand-contains fallback (prevents comments smearing onto operands).
- **RexSubQuery**: retain comments across `clone()` so subquery-boundary comments survive.
- Add `testCTEWithTraitsRetainsNameComment`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)