### PR TITLE
RSFB-4907 - CREATE TABLE AS using CTE with aliased reference in UNPIVOT

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/CTERelToSqlUtil.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/CTERelToSqlUtil.java
@@ -40,8 +40,8 @@ import org.apache.calcite.sql.SqlUpdate;
 import org.apache.calcite.sql.SqlWith;
 import org.apache.calcite.sql.SqlWithItem;
 import org.apache.calcite.sql.fun.SqlCase;
-import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.util.SqlShuttle;
 
 import java.util.ArrayList;

--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/CTERelToSqlUtil.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/CTERelToSqlUtil.java
@@ -41,6 +41,7 @@ import org.apache.calcite.sql.SqlWith;
 import org.apache.calcite.sql.SqlWithItem;
 import org.apache.calcite.sql.fun.SqlCase;
 import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.util.SqlShuttle;
 
 import java.util.ArrayList;
@@ -56,14 +57,8 @@ public class CTERelToSqlUtil {
   }
 
   public static boolean isCteScopeTrait(RelTraitSet relTraitSet) {
-    boolean isCteScopeTrait = false;
     RelTrait relTrait = relTraitSet.getTrait(CTEScopeTraitDef.instance);
-    if (relTrait != null && relTrait instanceof CTEScopeTrait) {
-      if (((CTEScopeTrait) relTrait).isCTEScope()) {
-        isCteScopeTrait = true;
-      }
-    }
-    return isCteScopeTrait;
+    return relTrait instanceof CTEScopeTrait && ((CTEScopeTrait) relTrait).isCTEScope();
   }
 
   public static boolean isCTEScopeOrDefinitionTrait(RelTraitSet relTraitSet) {
@@ -71,14 +66,9 @@ public class CTERelToSqlUtil {
   }
 
   public static boolean isCteDefinationTrait(RelTraitSet relTraitSet) {
-    boolean isCteDefinationTrait = false;
     RelTrait relTrait = relTraitSet.getTrait(CTEDefinationTraitDef.instance);
-    if (relTrait != null && relTrait instanceof CTEDefinationTrait) {
-      if (((CTEDefinationTrait) relTrait).isCTEDefination()) {
-        isCteDefinationTrait = true;
-      }
-    }
-    return isCteDefinationTrait;
+    return relTrait instanceof CTEDefinationTrait
+        && ((CTEDefinationTrait) relTrait).isCTEDefination();
   }
 
   /**
@@ -292,15 +282,43 @@ public class CTERelToSqlUtil {
       } else {
         ((SqlSelect) sqlNode).setFrom(((SqlWithItem) fromNode).name);
       }
-    } else if (fromNode instanceof SqlUnpivot
-        && ((SqlUnpivot) fromNode).query instanceof SqlWithItem) {
-      SqlIdentifier identifier = ((SqlWithItem) ((SqlUnpivot) fromNode).query).name;
-      SqlUnpivot unpivot = (SqlUnpivot) fromNode;
-      SqlUnpivot unpivotNode =
-          new SqlUnpivot(unpivot.getParserPosition(), identifier, unpivot.includeNulls,
-              unpivot.measureList, unpivot.axisList, unpivot.inList);
-      ((SqlSelect) sqlNode).setFrom(unpivotNode);
+    } else if (fromNode instanceof SqlUnpivot) {
+      // Replace inline CTE body in the UNPIVOT's query with just the CTE identifier
+      // (or AS(identifier, alias) when the CTE reference carries a table alias).
+      SqlNode resolvedQuery = resolveUnpivotCteQuery(((SqlUnpivot) fromNode).query);
+      if (resolvedQuery != null) {
+        SqlUnpivot unpivot = (SqlUnpivot) fromNode;
+        SqlUnpivot unpivotNode =
+            new SqlUnpivot(unpivot.getParserPosition(), resolvedQuery, unpivot.includeNulls,
+                unpivot.measureList, unpivot.axisList, unpivot.inList);
+
+        ((SqlSelect) sqlNode).setFrom(unpivotNode);
+      }
     }
+  }
+
+  /**
+   * Returns the replacement query node for an UNPIVOT whose source is a CTE reference,
+   * or {@code null} if no substitution is needed.
+   *
+   * <ul>
+   *   <li>Unaliased ({@code FROM cte UNPIVOT}): query is {@link SqlWithItem}; returns
+   *       the CTE {@link SqlIdentifier}.</li>
+   *   <li>Aliased ({@code FROM cte alias UNPIVOT}): query is {@code AS(SqlWithItem, alias)};
+   *       returns {@code AS(SqlIdentifier, alias)}.</li>
+   * </ul>
+   */
+  private static SqlNode resolveUnpivotCteQuery(SqlNode query) {
+    if (query instanceof SqlWithItem) {
+      return ((SqlWithItem) query).name;
+    }
+    if (query instanceof SqlBasicCall
+        && ((SqlBasicCall) query).operand(0) instanceof SqlWithItem) {
+      SqlBasicCall asCall = (SqlBasicCall) query;
+      SqlIdentifier identifier = ((SqlWithItem) asCall.operand(0)).name;
+      return SqlStdOperatorTable.AS.createCall(SqlParserPos.ZERO, identifier, asCall.operand(1));
+    }
+    return null;
   }
 
   private static void processBasicCall(SqlNode sqlNode) {

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
@@ -12299,8 +12299,8 @@ class RelToSqlConverterDMTest {
 
     final CTEDefinationTrait cteTrait = new CTEDefinationTrait(true, "TMP", false);
     final TableAliasTrait aliasTrait = new TableAliasTrait("a");
-    final RelNode cteRel = cteBody.copy(
-        cteBody.getTraitSet().plus(cteTrait).plus(aliasTrait), cteBody.getInputs());
+    final RelNode cteRel =
+        cteBody.copy(cteBody.getTraitSet().plus(cteTrait).plus(aliasTrait), cteBody.getInputs());
 
     final RelNode unpivotRel = builder
         .push(cteRel)
@@ -12317,8 +12317,8 @@ class RelToSqlConverterDMTest {
         .build();
 
     final CTEScopeTrait cteScopeTrait = new CTEScopeTrait(true);
-    final RelNode root = unpivotRel.copy(
-        unpivotRel.getTraitSet().plus(cteScopeTrait), unpivotRel.getInputs());
+    final RelNode root =
+        unpivotRel.copy(unpivotRel.getTraitSet().plus(cteScopeTrait), unpivotRel.getInputs());
 
     // Key: "FROM TMP AS a UNPIVOT" must appear - not the full CTE body inlined
     final String expectedSql = "WITH TMP AS (SELECT jansales, febsales, marsales\n"

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
@@ -12288,6 +12288,47 @@ class RelToSqlConverterDMTest {
     assertThat(actualSql, isLinux(expectedSql));
   }
 
+  /*FROM TMP A UNPIVOT(...) must produce
+    FROM TMP AS A UNPIVOT(...) not FROM (SELECT ...) AS A UNPIVOT(...)*/
+  @Test public void testCTASWithCTEAndAliasedReferenceInUnpivot() {
+    final RelBuilder builder = RelBuilder.create(salesConfig().build());
+    final RelNode cteBody = builder
+        .scan("sales")
+        .project(builder.field("jansales"), builder.field("febsales"), builder.field("marsales"))
+        .build();
+
+    final CTEDefinationTrait cteTrait = new CTEDefinationTrait(true, "TMP", false);
+    final TableAliasTrait aliasTrait = new TableAliasTrait("a");
+    final RelNode cteRel = cteBody.copy(
+        cteBody.getTraitSet().plus(cteTrait).plus(aliasTrait), cteBody.getInputs());
+
+    final RelNode unpivotRel = builder
+        .push(cteRel)
+        .unpivot(false,
+            ImmutableList.of("monthly_sales"),
+            ImmutableList.of("month"),
+            Pair.zip(
+                Arrays.asList(ImmutableList.of(builder.literal("jan")),
+                    ImmutableList.of(builder.literal("feb")),
+                    ImmutableList.of(builder.literal("march"))),
+                Arrays.asList(ImmutableList.of(builder.field("jansales")),
+                    ImmutableList.of(builder.field("febsales")),
+                    ImmutableList.of(builder.field("marsales")))))
+        .build();
+
+    final CTEScopeTrait cteScopeTrait = new CTEScopeTrait(true);
+    final RelNode root = unpivotRel.copy(
+        unpivotRel.getTraitSet().plus(cteScopeTrait), unpivotRel.getInputs());
+
+    // Key: "FROM TMP AS a UNPIVOT" must appear - not the full CTE body inlined
+    final String expectedSql = "WITH TMP AS (SELECT jansales, febsales, marsales\n"
+        + "FROM SALESSCHEMA.sales) "
+        + "(SELECT month, CAST(monthly_sales AS INTEGER) AS monthly_sales\n"
+        + "FROM TMP AS a UNPIVOT EXCLUDE NULLS (monthly_sales FOR month IN "
+        + "(jansales AS 'jan', febsales AS 'feb', marsales AS 'march')))";
+    assertThat(toSql(root, DatabaseProduct.BIG_QUERY.getDialect()), isLinux(expectedSql));
+  }
+
   @Test public void testGenerateUUID() {
     final RelBuilder builder = relBuilder();
     final RexNode generateUUID = builder.call(SqlLibraryOperators.GENERATE_UUID);


### PR DESCRIPTION
CTERelToSqlUtil.processFromNode() did not handle the case where a CTE referenced with a table alias appears as the source of an UNPIVOT — the full CTE body was inlined instead of using the CTE identifier. Added resolveUnpivotCteQuery() to unify both the aliased (AS(SqlWithItem, alias)) and unaliased (SqlWithItem) cases. Also simplified isCteScopeTrait() and isCteDefinationTrait() from verbose boolean-flag patterns to single-expression returns.