### PR TITLE
[SDD bench] RMSIB-59 — draft calcite change (reference; do not merge)

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -2109,6 +2109,19 @@ public abstract class SqlLibraryOperators {
           SqlFunctionCategory.STRING);
 
   /**
+   * The "BYTE_LENGTH(string_or_bytes)" function; returns the number of BYTES used to represent
+   * the argument. BigQuery-specific: for a STRING argument it counts UTF-8 bytes (not
+   * characters, unlike CHAR_LENGTH), and for a BYTES argument it counts the bytes directly.
+   * Returns NULL on a NULL argument.
+   */
+  @LibraryOperator(libraries = {BIG_QUERY})
+  public static final SqlFunction BYTE_LENGTH =
+      SqlBasicFunction.create("BYTE_LENGTH",
+          ReturnTypes.INTEGER_NULLABLE,
+          OperandTypes.or(OperandTypes.CHARACTER, OperandTypes.BINARY),
+          SqlFunctionCategory.STRING);
+
+  /**
    * The "FROM_HEX(varchar)" function; converts a hexadecimal-encoded {@code varchar} into bytes.
    */
   @LibraryOperator(libraries = {BIG_QUERY})

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
@@ -14515,4 +14515,46 @@ class RelToSqlConverterDMTest {
         + "FROM [scott].[EMP]";
     assertThat(toSql(root, DatabaseProduct.MSSQL.getDialect()), isLinux(expectedBiqQuery));
   }
+
+  @Test public void testByteLengthFunctionOnStringOperand() {
+    final RelBuilder builder = relBuilder().scan("EMP");
+    final RexNode byteLength =
+        builder.call(SqlLibraryOperators.BYTE_LENGTH, builder.field(1));
+    final RelNode root = builder
+        .project(builder.alias(byteLength, "len")).build();
+
+    final String expectedBiqQuery = "SELECT BYTE_LENGTH(ENAME) AS len\n"
+        + "FROM scott.EMP";
+    assertThat(toSql(root, DatabaseProduct.BIG_QUERY.getDialect()), isLinux(expectedBiqQuery));
+  }
+
+  @Test public void testByteLengthFunctionOnStringLiteralPreservesTrailingSpace() {
+    final RelBuilder builder = relBuilder();
+    final RexNode byteLength =
+        builder.call(SqlLibraryOperators.BYTE_LENGTH, builder.literal("abc "));
+    final RelNode root = builder.scan("EMP")
+        .project(builder.alias(byteLength, "len")).build();
+
+    final String expectedBiqQuery = "SELECT BYTE_LENGTH('abc ') AS len\n"
+        + "FROM scott.EMP";
+    assertThat(toSql(root, DatabaseProduct.BIG_QUERY.getDialect()), isLinux(expectedBiqQuery));
+  }
+
+  /** BYTE_LENGTH over the byte materialization of a fixed-width numeric — the shape a
+   * MS SQL Server DATALENGTH(INT) lowers to (RMSIB-59). Proves the whole composition
+   * BYTE_LENGTH(FROM_HEX(FORMAT('%08x', n))) round-trips through rel2sql for BigQuery. */
+  @Test public void testByteLengthOverFromHexFormatOnIntOperand() {
+    final RelBuilder builder = relBuilder();
+    final RexNode formatted =
+        builder.call(SqlLibraryOperators.FORMAT, builder.literal("%08x"), builder.literal(12345));
+    final RexNode fromHex = builder.call(SqlLibraryOperators.FROM_HEX, formatted);
+    final RexNode byteLength = builder.call(SqlLibraryOperators.BYTE_LENGTH, fromHex);
+    final RelNode root = builder.scan("EMP")
+        .project(builder.alias(byteLength, "len")).build();
+
+    final String expectedBiqQuery =
+        "SELECT BYTE_LENGTH(FROM_HEX(FORMAT('%08x', 12345))) AS len\n"
+        + "FROM scott.EMP";
+    assertThat(toSql(root, DatabaseProduct.BIG_QUERY.getDialect()), isLinux(expectedBiqQuery));
+  }
 }


### PR DESCRIPTION
SDD benchmark reference — RMSIB-59, run 2026-07-28-RMSIB-59-02.
Reference only — never merge. Base = the pre-dev-fix pinned commit, so the diff shows SDD's change against the code the dev saw.
base = aa64211f7b7b; head = bench/2026-07-28-RMSIB-59-02/sdd. Both live in the bench/ namespace — nothing here targets master, exactly like the mig-side reference MRs.
Published by wren/benchmark-replay/scripts/push-calcite-reference-pr.sh; it deliberately carries nothing beyond the Jira id, the run id and the pinned sha.