### PR TITLE
[SDD bench] RTB-2332 — draft calcite change (reference; do not merge)

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
@@ -71,6 +71,7 @@ import org.apache.calcite.sql.type.SqlTypeUtil;
 import org.apache.calcite.sql.validate.SqlConformanceEnum;
 import org.apache.calcite.util.CastCallBuilder;
 import org.apache.calcite.util.NlsString;
+import org.apache.calcite.util.RegexAnchorUtil;
 import org.apache.calcite.util.SqlCommentUtil;
 import org.apache.calcite.util.TimestampString;
 import org.apache.calcite.util.ToNumberUtils;
@@ -1830,7 +1831,19 @@ public class BigQuerySqlDialect extends SqlDialect {
       SqlWriter writer, SqlCall call, String operatorName) {
     SqlCharStringLiteral secondOperand = call.getOperandList().size() == 3
         ? modifyIfRegexpContainsSecondOperand(call) : call.operand(1);
+    // Teradata REGEXP_SIMILAR is a whole-string match, but REGEXP_CONTAINS is a substring
+    // search, so the pattern must be anchored. REGEXP_LIKE deliberately shares this helper
+    // and must NOT be anchored -- Oracle/Db2 REGEXP_LIKE is genuinely a partial match.
+    if ("REGEXP_SIMILAR".equals(operatorName)) {
+      secondOperand = anchorRegexLiteral(secondOperand);
+    }
     unparseRegexLiteral(writer, secondOperand, operatorName);
+  }
+
+  private static SqlCharStringLiteral anchorRegexLiteral(SqlCharStringLiteral operand) {
+    String anchored = RegexAnchorUtil.anchorForWholeStringMatch(
+        removeLeadingAndTrailingSingleQuotes(operand.toString()));
+    return SqlLiteral.createCharString(anchored, SqlParserPos.ZERO);
   }
 
   private SqlCharStringLiteral modifyIfRegexpContainsSecondOperand(SqlCall call) {

--- a/core/src/main/java/org/apache/calcite/sql/dialect/SparkSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/SparkSqlDialect.java
@@ -995,12 +995,29 @@ public class SparkSqlDialect extends SqlDialect {
   }
 
   private void unParseRegexString(SqlWriter writer, SqlCall call, int leftPrec, int rightPrec) {
+    // Spark/Databricks `rlike` is a find() style partial match, so a whole-string source
+    // predicate (Teradata REGEXP_SIMILAR) must have its pattern anchored. unParseRegexpLike
+    // is reached only from `case "REGEXP_SIMILAR"` in this dialect, but the operator name is
+    // checked explicitly so a future REGEXP_LIKE caller is not silently anchored too.
+    boolean anchor = "REGEXP_SIMILAR".equals(call.getOperator().getName());
     if (call.getOperandList().size() == 3) {
       SqlCharStringLiteral modifiedRegexString = getModifiedRegexString(call);
+      if (anchor) {
+        modifiedRegexString = anchorRegexLiteral(modifiedRegexString);
+      }
       modifiedRegexString.unparse(writer, leftPrec, rightPrec);
+    } else if (anchor && call.operand(1) instanceof SqlCharStringLiteral) {
+      anchorRegexLiteral((SqlCharStringLiteral) call.operand(1))
+          .unparse(writer, leftPrec, rightPrec);
     } else {
       call.operand(1).unparse(writer, leftPrec, rightPrec);
     }
+  }
+
+  private static SqlCharStringLiteral anchorRegexLiteral(SqlCharStringLiteral operand) {
+    String raw = operand.toValue();
+    return SqlLiteral.createCharString(
+        RegexAnchorUtil.anchorForWholeStringMatch(raw), SqlParserPos.ZERO);
   }
 
   private SqlCharStringLiteral getModifiedRegexString(SqlCall call) {

--- a/core/src/main/java/org/apache/calcite/util/RegexAnchorUtil.java
+++ b/core/src/main/java/org/apache/calcite/util/RegexAnchorUtil.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.util;
+
+/**
+ * Anchors a regular expression so that a target dialect whose predicate is a
+ * <em>substring</em> matcher (BigQuery {@code REGEXP_CONTAINS}, Spark {@code rlike})
+ * reproduces the <em>whole-string</em> semantics of source predicates such as
+ * Teradata {@code REGEXP_SIMILAR}.
+ *
+ * <p>The transform is idempotent, so it may be applied to a pattern that another
+ * unparse step has already anchored.
+ */
+public class RegexAnchorUtil {
+
+  private RegexAnchorUtil() {
+  }
+
+  /**
+   * Returns {@code regex} anchored for a whole-string match.
+   *
+   * <p>Rules, in order:
+   * <ol>
+   * <li>already anchored at both ends -&gt; returned unchanged (idempotence);</li>
+   * <li>an edge {@code ^}/{@code $} counts only when <em>unescaped</em>, so
+   *     {@code end\$} still gains real anchors;</li>
+   * <li>a <em>top-level</em> {@code |} is wrapped in a non-capturing group first,
+   *     because {@code ^a|b$} means {@code ^a} OR {@code b$} rather than a whole-string
+   *     match;</li>
+   * <li>otherwise only the missing side is added.</li>
+   * </ol>
+   */
+  public static String anchorForWholeStringMatch(String regex) {
+    if (regex == null) {
+      return null;
+    }
+    boolean startAnchored = regex.startsWith("^");
+    boolean endAnchored = endsWithUnescapedDollar(regex);
+    if (startAnchored && endAnchored) {
+      return regex;
+    }
+    if (hasTopLevelAlternation(regex)) {
+      // The existing edge anchors, if any, become per-branch once grouped, so both
+      // anchors are (re)applied around the group.
+      return "^(?:" + regex + ")$";
+    }
+    return (startAnchored ? "" : "^") + regex + (endAnchored ? "" : "$");
+  }
+
+  /**
+   * Returns whether {@code regex} ends with a {@code $} that is an anchor rather than
+   * an escaped literal dollar sign.
+   */
+  private static boolean endsWithUnescapedDollar(String regex) {
+    if (!regex.endsWith("$")) {
+      return false;
+    }
+    int backslashes = 0;
+    for (int i = regex.length() - 2; i >= 0 && regex.charAt(i) == '\\'; i--) {
+      backslashes++;
+    }
+    return backslashes % 2 == 0;
+  }
+
+  /**
+   * Returns whether {@code regex} contains an alternation {@code |} at nesting depth
+   * zero, ignoring escaped characters and the contents of character classes.
+   */
+  private static boolean hasTopLevelAlternation(String regex) {
+    int depth = 0;
+    boolean inCharClass = false;
+    for (int i = 0; i < regex.length(); i++) {
+      char c = regex.charAt(i);
+      if (c == '\\') {
+        i++;
+        continue;
+      }
+      if (inCharClass) {
+        if (c == ']') {
+          inCharClass = false;
+        }
+        continue;
+      }
+      switch (c) {
+      case '[':
+        inCharClass = true;
+        break;
+      case '(':
+        depth++;
+        break;
+      case ')':
+        depth--;
+        break;
+      case '|':
+        if (depth == 0) {
+          return true;
+        }
+        break;
+      default:
+        break;
+      }
+    }
+    return false;
+  }
+}

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
@@ -9278,6 +9278,87 @@ class RelToSqlConverterDMTest {
     assertThat(toSql(root, DatabaseProduct.SPARK.getDialect()), isLinux(expectedSparkSql));
   }
 
+  /** Test case for RTB-2332: a Teradata REGEXP_SIMILAR pattern that the source did NOT anchor
+   * must be anchored for the substring-matching targets, so whole-string semantics survive.
+   * The existing testForRegexpSimilarFunction covers the already-anchored (idempotent) case. */
+  @Test public void testForRegexpSimilarFunctionAnchorsUnanchoredPattern() {
+    final RelBuilder builder = relBuilder();
+    final RexNode regexpSimilar =
+        builder.call(SqlLibraryOperators.REGEXP_SIMILAR, builder.literal("12345"),
+                builder.literal("[0-9]*"));
+    final RelNode root = builder
+        .scan("EMP")
+        .project(builder.alias(regexpSimilar, "A"))
+        .build();
+
+    final String expectedBiqQuery = "SELECT IF(REGEXP_CONTAINS('12345' , "
+        + "r'^[0-9]*$'), 1, 0) AS A\n"
+        + "FROM scott.EMP";
+
+    final String expectedSparkSql = "SELECT IF('12345' rlike r'^[0-9]*$', 1, 0)"
+        + " A\nFROM scott.EMP";
+
+    assertThat(toSql(root, DatabaseProduct.BIG_QUERY.getDialect()), isLinux(expectedBiqQuery));
+    assertThat(toSql(root, DatabaseProduct.SPARK.getDialect()), isLinux(expectedSparkSql));
+  }
+
+  /** Test case for RTB-2332: a top-level alternation must be grouped before anchoring,
+   * otherwise '^a|b$' would mean '^a' OR 'b$' instead of a whole-string match. */
+  @Test public void testForRegexpSimilarFunctionGroupsTopLevelAlternation() {
+    final RelBuilder builder = relBuilder();
+    final RexNode regexpSimilar =
+        builder.call(SqlLibraryOperators.REGEXP_SIMILAR, builder.literal("Mike Bird"),
+                builder.literal("(Mike B(i|y)rd)|(Michael B(i|y)rd)"));
+    final RelNode root = builder
+        .scan("EMP")
+        .project(builder.alias(regexpSimilar, "A"))
+        .build();
+
+    final String expectedBiqQuery = "SELECT IF(REGEXP_CONTAINS('Mike Bird' , "
+        + "r'^(?:(Mike B(i|y)rd)|(Michael B(i|y)rd))$'), 1, 0) AS A\n"
+        + "FROM scott.EMP";
+
+    assertThat(toSql(root, DatabaseProduct.BIG_QUERY.getDialect()), isLinux(expectedBiqQuery));
+  }
+
+  /** Test case for RTB-2332: an escaped trailing dollar is a literal '$', not an anchor,
+   * so real anchors are still added. */
+  @Test public void testForRegexpSimilarFunctionAnchorsEscapedDollarPattern() {
+    final RelBuilder builder = relBuilder();
+    final RexNode regexpSimilar =
+        builder.call(SqlLibraryOperators.REGEXP_SIMILAR, builder.literal("end$"),
+                builder.literal("end\\$"));
+    final RelNode root = builder
+        .scan("EMP")
+        .project(builder.alias(regexpSimilar, "A"))
+        .build();
+
+    final String expectedBiqQuery = "SELECT IF(REGEXP_CONTAINS('end$' , "
+        + "r'^end\\$$'), 1, 0) AS A\n"
+        + "FROM scott.EMP";
+
+    assertThat(toSql(root, DatabaseProduct.BIG_QUERY.getDialect()), isLinux(expectedBiqQuery));
+  }
+
+  /** Test case for RTB-2332: the 3-operand 'i' form is already anchored by
+   * modifyRegexStringForMatchArgumentI, so anchoring must be a no-op there. */
+  @Test public void testForRegexpSimilarFunctionMatchArgumentIStaysSingleAnchored() {
+    final RelBuilder builder = relBuilder();
+    final RexNode regexpSimilar =
+        builder.call(SqlLibraryOperators.REGEXP_SIMILAR, builder.literal("MiKe BIrd"),
+                builder.literal("(Mike B(i|y)rd)"), builder.literal("i"));
+    final RelNode root = builder
+        .scan("EMP")
+        .project(builder.alias(regexpSimilar, "A"))
+        .build();
+
+    final String expectedBiqQuery = "SELECT IF(REGEXP_CONTAINS('MiKe BIrd' , "
+        + "r'^(?i)(Mike B(i|y)rd)$'), 1, 0) AS A\n"
+        + "FROM scott.EMP";
+
+    assertThat(toSql(root, DatabaseProduct.BIG_QUERY.getDialect()), isLinux(expectedBiqQuery));
+  }
+
   @Test public void testForRegexpSimilarFunctionWithThirdArgumentAsI() {
     final RelBuilder builder = relBuilder();
     final RexNode regexpSimilar =


### PR DESCRIPTION
SDD benchmark reference — RTB-2332, run 2026-07-29-RTB-2332-01.
Reference only — never merge. Base = the pre-dev-fix pinned commit, so the diff shows SDD's change against the code the dev saw.
base = 157388e92754; head = bench/2026-07-29-RTB-2332-01/sdd. Both live in the bench/ namespace — nothing here targets master, exactly like the mig-side reference MRs.
Published by wren/benchmark-replay/scripts/push-calcite-reference-pr.sh; it deliberately carries nothing beyond the Jira id, the run id and the pinned sha.