### PR TITLE
[dev reference] RTB-2332 — developer's calcite change (reference; do not merge)

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
@@ -1764,13 +1764,11 @@ public class BigQuerySqlDialect extends SqlDialect {
   }
 
   private void unParseRegexpSimilar(SqlWriter writer, SqlCall call, int leftPrec, int rightPrec) {
-    SqlWriter.Frame ifFrame = writer.startFunCall("IF");
+    final SqlWriter.Frame castFrame = writer.startFunCall("CAST");
     unparseIfRegexpContains(writer, call, leftPrec, rightPrec, call.getOperator().getName());
-    writer.sep(",");
-    writer.literal("1");
-    writer.sep(",");
-    writer.literal("0");
-    writer.endFunCall(ifFrame);
+    writer.sep("AS");
+    writer.literal("INT64");
+    writer.endFunCall(castFrame);
   }
 
   private void unparseShiftLeftAndShiftRight(SqlWriter writer, SqlCall call, boolean isShiftLeft) {
@@ -1828,9 +1826,28 @@ public class BigQuerySqlDialect extends SqlDialect {
 
   private void unparseRegexStringForIfRegexReplace(
       SqlWriter writer, SqlCall call, String operatorName) {
-    SqlCharStringLiteral secondOperand = call.getOperandList().size() == 3
-        ? modifyIfRegexpContainsSecondOperand(call) : call.operand(1);
+    SqlCharStringLiteral secondOperand;
+    if (call.getOperandList().size() == 3) {
+      secondOperand = modifyIfRegexpContainsSecondOperand(call);
+    } else if ("REGEXP_SIMILAR".equals(operatorName)) {
+      secondOperand = anchorRegexForFullMatch(call.operand(1));
+    } else {
+      secondOperand = call.operand(1);
+    }
     unparseRegexLiteral(writer, secondOperand, operatorName);
+  }
+
+  /**
+   * Wraps the regex pattern with '^' and '$' anchors for full-string matching.
+   * Teradata REGEXP_SIMILAR always performs a full-string match, so the BigQuery
+   * REGEXP_CONTAINS equivalent must be anchored.
+   */
+  private static SqlCharStringLiteral anchorRegexForFullMatch(SqlNode patternNode) {
+    String pattern = removeLeadingAndTrailingSingleQuotes(patternNode.toString());
+    if (!(pattern.startsWith("^") && pattern.endsWith("$"))) {
+      pattern = "^" + pattern + "$";
+    }
+    return SqlLiteral.createCharString(pattern, SqlParserPos.ZERO);
   }
 
   private SqlCharStringLiteral modifyIfRegexpContainsSecondOperand(SqlCall call) {

--- a/core/src/main/java/org/apache/calcite/sql/fun/JsonTupleFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/JsonTupleFunction.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql.fun;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlOperatorBinding;
+import org.apache.calcite.sql.SqlTableFunction;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlReturnTypeInference;
+
+import java.util.Map;
+
+/**
+ * class For Hive JSON_TUPLE Function.
+ */
+public class JsonTupleFunction extends SqlFunction implements SqlTableFunction {
+
+  private final Map<String, RelDataType> columnDefinitions;
+
+  public JsonTupleFunction(Map<String, RelDataType> columnDefinitions) {
+    super("JSON_TUPLE",
+        SqlKind.OTHER_FUNCTION,
+        ReturnTypes.COLUMN_LIST,
+        null,
+        OperandTypes.VARIADIC,
+        SqlFunctionCategory.USER_DEFINED_TABLE_FUNCTION);
+    this.columnDefinitions = columnDefinitions;
+  }
+
+  @Override public SqlReturnTypeInference getRowTypeInference() {
+    return this::getRowType;
+  }
+
+  public RelDataType getRowType(SqlOperatorBinding opBinding) {
+    final RelDataTypeFactory.Builder builder =
+        opBinding.getTypeFactory().builder();
+    for (Map.Entry<String, RelDataType> entry : columnDefinitions.entrySet()) {
+      builder.add(entry.getKey(), entry.getValue());
+    }
+    return builder.build();
+  }
+
+  public Map<String, RelDataType> getColumnDefinitions() {
+    return columnDefinitions;
+  }
+}

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
@@ -92,6 +92,7 @@ import org.apache.calcite.sql.fun.BQRangeSessionizeTableFunction;
 import org.apache.calcite.sql.fun.GeneratorTableFunction;
 import org.apache.calcite.sql.fun.HiveLateralViewExplodeFunction;
 import org.apache.calcite.sql.fun.HiveTableValueFunction;
+import org.apache.calcite.sql.fun.JsonTupleFunction;
 import org.apache.calcite.sql.fun.SqlAddMonths;
 import org.apache.calcite.sql.fun.SqlLibrary;
 import org.apache.calcite.sql.fun.SqlLibraryOperatorTableFactory;
@@ -9267,8 +9268,8 @@ class RelToSqlConverterDMTest {
         .project(builder.alias(regexpSimilar, "A"))
         .build();
 
-    final String expectedBiqQuery = "SELECT IF(REGEXP_CONTAINS('12-12-2000' , "
-        + "r'^\\d\\d-\\w{2}-\\d{4}$'), 1, 0) AS A\n"
+    final String expectedBiqQuery = "SELECT CAST(REGEXP_CONTAINS('12-12-2000' , "
+        + "r'^\\d\\d-\\w{2}-\\d{4}$') AS INT64) AS A\n"
         + "FROM scott.EMP";
 
     final String expectedSparkSql = "SELECT IF('12-12-2000' rlike r'^\\d\\d-\\w{2}-\\d{4}$', 1, 0)"
@@ -9288,8 +9289,8 @@ class RelToSqlConverterDMTest {
         .project(builder.alias(regexpSimilar, "A"))
         .build();
 
-    final String expectedBiqQuery = "SELECT IF(REGEXP_CONTAINS('Mike BIrd' , "
-        + "r'^(?i)MikE B(i|y)RD$'), 1, 0) AS A\n"
+    final String expectedBiqQuery = "SELECT CAST(REGEXP_CONTAINS('Mike BIrd' , "
+        + "r'^(?i)MikE B(i|y)RD$') AS INT64) AS A\n"
         + "FROM scott.EMP";
 
     final String expectedSparkSql = "SELECT IF('Mike BIrd' rlike r'(?i)MikE B(i|y)RD', 1, 0)"
@@ -9309,7 +9310,7 @@ class RelToSqlConverterDMTest {
         .project(builder.alias(regexpSimilar, "A"))
         .build();
 
-    final String expectedBiqQuery = "SELECT IF(REGEXP_CONTAINS('Mike' , r'Mike'), 1, 0) AS A\n"
+    final String expectedBiqQuery = "SELECT CAST(REGEXP_CONTAINS('Mike' , r'Mike') AS INT64) AS A\n"
         + "FROM scott.EMP";
 
     final String expectedSparkSql = "SELECT IF('Mike' rlike r'(?x)M i k e', 1, 0)"
@@ -9330,8 +9331,8 @@ class RelToSqlConverterDMTest {
         .project(builder.alias(regexpSimilar, "A"))
         .build();
 
-    final String expectedBiqQuery = "SELECT IF(REGEXP_CONTAINS('Mike Bird' , "
-        + "r'Mike B(i|y)RD'), 1, 0) AS A\n"
+    final String expectedBiqQuery = "SELECT CAST(REGEXP_CONTAINS('Mike Bird' , "
+        + "r'Mike B(i|y)RD') AS INT64) AS A\n"
         + "FROM scott.EMP";
 
     final String expectedSparkSql = "SELECT IF('Mike Bird' rlike r'Mike B(i|y)RD', 1, 0)"
@@ -10775,7 +10776,7 @@ class RelToSqlConverterDMTest {
         .build();
 
     final String expectedBiqQuery = "SELECT "
-        + "IF(REGEXP_CONTAINS('12-12-2000' , r'^\\d\\d-\\w{2}-\\d{4}$'), 1, 0) AS regexpLike, "
+        + "CAST(REGEXP_CONTAINS('12-12-2000' , r'^\\d\\d-\\w{2}-\\d{4}$') AS INT64) AS regexpLike, "
         + "REGEXP_EXTRACT('Calcite', '\\.', 'DM.') AS regexpExtract, "
         + "REGEXP_REPLACE('Calcite', '\\.', 'DM.') AS regexpReplace\n"
         + "FROM scott.EMP";
@@ -11029,6 +11030,23 @@ class RelToSqlConverterDMTest {
         builder.functionScan(new HiveLateralViewExplodeFunction(tableFunRowType), 0, operands).build();
     final String expectedQuery = "SELECT *\n"
         + "FROM TABLE(LATERAL VIEW EXPLODE(MAP['key_name', 'value_name']))";
+
+    assertThat(toSql(root, DatabaseProduct.HIVE.getDialect()), isLinux(expectedQuery));
+  }
+
+  @Test public void testLateralViewJsonTupleFunction() {
+    final RelBuilder builder = foodmartRelBuilder();
+    Map<String, RelDataType> tableFunRowType = new HashMap<>();
+    builder.scan("employee");
+    RexNode operand =
+        builder.call(
+            new JsonTupleFunction(tableFunRowType), builder.field(1), builder.literal(
+                "key1"),
+            builder.literal("key2"));
+    RelNode root =
+        builder.project(operand).build();
+    final String expectedQuery = "SELECT JSON_TUPLE(full_name, 'key1', 'key2') $f0\n"
+        + "FROM foodmart.employee";
 
     assertThat(toSql(root, DatabaseProduct.HIVE.getDialect()), isLinux(expectedQuery));
   }


### PR DESCRIPTION
SDD benchmark reference — RTB-2332, run 2026-07-29-RTB-2332-01.
Reference only — never merge. Base = the pre-dev-fix pinned commit, so the diff shows SDD's change against the code the dev saw.
base = 157388e92754; head = bench/2026-07-29-RTB-2332-01/dev. Both live in the bench/ namespace — nothing here targets master, exactly like the mig-side reference MRs.
Published by wren/benchmark-replay/scripts/push-calcite-reference-pr.sh; it deliberately carries nothing beyond the Jira id, the run id and the pinned sha.