### PR TITLE
[SDD bench] RMSB-206 — draft calcite change (reference; do not merge)

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
@@ -2089,7 +2089,11 @@ public class BigQuerySqlDialect extends SqlDialect {
     int indexOfRegexOperand = 1;
     SqlWriter.Frame regexpReplaceFrame = writer.startFunCall("REGEXP_INSTR");
     List<SqlNode> operandList = call.getOperandList();
-    unparseRegexFunctionsOperands(writer, leftPrec, rightPrec, indexOfRegexOperand, operandList);
+    // BigQuery regex arguments must be raw string literals: a non-raw literal makes the
+    // backslash-bearing pattern an invalid escape sequence ('\.' -> "Illegal escape sequence"),
+    // so REGEXP_INSTR gets the same r'...' treatment REGEXP_CONTAINS already has.
+    unparseRegexpContainsFunctionsOperands(writer, leftPrec, rightPrec, indexOfRegexOperand,
+        operandList);
     writer.endFunCall(regexpReplaceFrame);
   }
 

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
@@ -3705,13 +3705,27 @@ class RelToSqlConverterDMTest {
         + "REGEXP_INSTR('Hello, Hello, World!', 'Hello', 2, 1) AS \"position3\", "
         + "REGEXP_INSTR('Hello, Hello, World!', 'Hello', 2, 1, 1) AS \"position4\"\n"
         + "FROM \"scott\".\"EMP\"";
-    final String expectedBiqQuery = "SELECT REGEXP_INSTR('Hello, Hello, World!', 'Hello') "
+    final String expectedBiqQuery = "SELECT REGEXP_INSTR('Hello, Hello, World!', r'Hello') "
         + "AS position1, "
-        + "REGEXP_INSTR('Hello, Hello, World!', 'Hello', 2) AS position2, "
-        + "REGEXP_INSTR('Hello, Hello, World!', 'Hello', 2, 1) AS position3, "
-        + "REGEXP_INSTR('Hello, Hello, World!', 'Hello', 2, 1, 1) AS position4\n"
+        + "REGEXP_INSTR('Hello, Hello, World!', r'Hello', 2) AS position2, "
+        + "REGEXP_INSTR('Hello, Hello, World!', r'Hello', 2, 1) AS position3, "
+        + "REGEXP_INSTR('Hello, Hello, World!', r'Hello', 2, 1, 1) AS position4\n"
         + "FROM scott.EMP";
     assertThat(toSql(root, DatabaseProduct.CALCITE.getDialect()), isLinux(expectedSql));
+    assertThat(toSql(root, DatabaseProduct.BIG_QUERY.getDialect()), isLinux(expectedBiqQuery));
+  }
+
+  /** Proves that a BigQuery REGEXP_INSTR pattern carrying a regex escape is emitted as a raw
+   * string literal, so the backslash reaches BigQuery instead of being read as a string escape. */
+  @Test public void testRegexpInstrEmitsRawStringPatternForEscapedMetacharacter() {
+    final RelBuilder builder = relBuilder();
+    final RexNode regexpInstr =
+        builder.call(SqlLibraryOperators.REGEXP_INSTR, builder.literal("a.com"),
+                builder.literal("(?i)\\.com$"));
+    final RelNode root = builder.scan("EMP")
+        .project(builder.alias(regexpInstr, "position1")).build();
+    final String expectedBiqQuery = "SELECT REGEXP_INSTR('a.com', r'(?i)\\.com$') AS position1\n"
+        + "FROM scott.EMP";
     assertThat(toSql(root, DatabaseProduct.BIG_QUERY.getDialect()), isLinux(expectedBiqQuery));
   }
 


### PR DESCRIPTION
SDD benchmark reference — RMSB-206, run 2026-07-29-RMSB-206.
Reference only — never merge. Base = the pre-dev-fix pinned commit, so the diff shows SDD's change against the code the dev saw.
base = 3d089990eaa8; head = bench/2026-07-29-RMSB-206/sdd. Both live in the bench/ namespace — nothing here targets master, exactly like the mig-side reference MRs.
Published by wren/benchmark-replay/scripts/push-calcite-reference-pr.sh; it deliberately carries nothing beyond the Jira id, the run id and the pinned sha.