### PR TITLE
[SDD bench] RMSIB-208 — draft calcite change (reference; do not merge)

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql2rel/RelDecorrelator.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/RelDecorrelator.java
@@ -43,6 +43,7 @@ import org.apache.calcite.rel.core.Join;
 import org.apache.calcite.rel.core.JoinRelType;
 import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.core.RelFactories;
+import org.apache.calcite.rel.core.SetOp;
 import org.apache.calcite.rel.core.Sort;
 import org.apache.calcite.rel.core.Values;
 import org.apache.calcite.rel.logical.LogicalAggregate;
@@ -52,6 +53,7 @@ import org.apache.calcite.rel.logical.LogicalJoin;
 import org.apache.calcite.rel.logical.LogicalProject;
 import org.apache.calcite.rel.logical.LogicalSnapshot;
 import org.apache.calcite.rel.logical.LogicalTableFunctionScan;
+import org.apache.calcite.rel.logical.LogicalUnion;
 import org.apache.calcite.rel.metadata.RelMdUtil;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.rel2sql.CTERelToSqlUtil;
@@ -936,6 +938,53 @@ public class RelDecorrelator implements ReflectiveVisitor {
       }
     }
     return null;
+  }
+
+  public @Nullable Frame decorrelateRel(LogicalUnion rel, boolean isCorVarDefined) {
+    return decorrelateRel((SetOp) rel, isCorVarDefined);
+  }
+
+  /**
+   * Decorrelate a SetOp (UNION [ALL] / INTERSECT / EXCEPT) whose inputs may carry correlated
+   * variables. Each input is decorrelated independently; all inputs must expose the SAME set of
+   * correlated defs (same CorDef -> output position), so the corVar columns line up across branches.
+   * The rebuilt SetOp then propagates those corDefOutputs up, so a parent Correlate can be lowered
+   * to a join (CALCITE-7272). Without this handler a SetOp falls to decorrelateRel(RelNode), which
+   * returns null the moment any input still carries corDefOutputs, aborting the whole decorrelation.
+   */
+  public @Nullable Frame decorrelateRel(SetOp rel, boolean isCorVarDefined) {
+    final List<RelNode> oldInputs = rel.getInputs();
+    final List<RelNode> newInputs = new ArrayList<>();
+    NavigableMap<CorDef, Integer> corDefOutputs = null;
+    Map<Integer, Integer> oldToNewOutputs = null;
+
+    for (RelNode oldInput : oldInputs) {
+      final Frame frame = getInvoke(oldInput, isCorVarDefined, rel);
+      if (frame == null) {
+        // an input could not be rewritten -> cannot decorrelate the SetOp
+        return null;
+      }
+      // All SetOp branches must agree on the correlated-var column layout, otherwise the union of
+      // rows would misalign the propagated corVars. Require identical CorDef->position maps.
+      if (corDefOutputs == null) {
+        corDefOutputs = new TreeMap<>(frame.corDefOutputs);
+        oldToNewOutputs = frame.oldToNewOutputs;
+      } else if (!corDefOutputs.equals(frame.corDefOutputs)) {
+        return null;
+      }
+      newInputs.add(frame.r);
+    }
+    if (corDefOutputs == null) {
+      return null;
+    }
+
+    // Rebuild the SetOp over the decorrelated inputs (all now carry the extra corVar columns in the
+    // same positions), preserving ALL/DISTINCT.
+    final RelNode newSetOp = rel.copy(rel.getTraitSet(), newInputs, rel.all);
+
+    // Output row shape is unchanged relative to each branch's decorrelated output, so reuse the
+    // per-branch oldToNewOutputs mapping and propagate the shared corDefOutputs upward.
+    return register(rel, newSetOp, oldToNewOutputs, corDefOutputs);
   }
 
   public @Nullable Frame decorrelateRel(LogicalProject rel, boolean isCorVarDefined) {

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
@@ -15156,4 +15156,16 @@ class RelToSqlConverterDMTest {
         + "WHERE EMP.EMPNO > 5";
     assertThat(actualSql, isLinux(expectedSql));
   }
+  @Test void testDecorrelateOuterApplyOverUnionAllAggregate() {
+    // OUTER APPLY (SELECT MAX(x) FROM (SELECT MAX(x) ... WHERE k=a.k UNION ALL SELECT MAX(x) ... WHERE k=a.k))
+    // must decorrelate to a LEFT JOIN on a GROUP BY-ed union, with NO LATERAL / correlate surviving.
+    final String sql = "SELECT a.k, b.mx FROM (SELECT DISTINCT k FROM t0) a "
+        + "OUTER APPLY (SELECT MAX(x) AS mx FROM ("
+        + "  SELECT MAX(x) AS x FROM t1 WHERE t1.k = a.k "
+        + "  UNION ALL "
+        + "  SELECT MAX(x) AS x FROM t2 WHERE t2.k = a.k) u) b";
+    // Expected (BigQuery): LEFT JOIN over grouped union; assert the rel decorrelates (no LogicalCorrelate
+    // in the optimized plan) and the emitted SQL contains "LEFT JOIN" and no "LATERAL".
+    sql(sql).withBigQuery().ok(/* expected LEFT JOIN form -- no LATERAL */);
+  }
 }


### PR DESCRIPTION
SDD benchmark reference — RMSIB-208, run 2026-08-10-RMSIB-208.
Reference only — never merge. Base = the pre-dev-fix pinned commit, so the diff shows SDD's change against the code the dev saw.
base = e092dcdee42f; head = bench/2026-08-10-RMSIB-208/sdd. Both live in the bench/ namespace — nothing here targets master, exactly like the mig-side reference MRs.
Published by wren/benchmark-replay/scripts/push-calcite-reference-pr.sh; it deliberately carries nothing beyond the Jira id, the run id and the pinned sha.

---
Provenance note: the SDD's raw report-only draft used prose blueprint markers (`@@ // ...`) and did not `git apply`. This diff was re-anchored by hand against the pinned base so it is viewable; the +/- code content is the SDD's exact output — only the hunk headers/context were repaired. See benchmark note calcite_ref_note.