### PR TITLE
[SDD bench] RSFB-4907 — draft calcite change (reference; do not merge)

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/CTERelToSqlUtil.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/CTERelToSqlUtil.java
@@ -292,15 +292,38 @@ public class CTERelToSqlUtil {
       } else {
         ((SqlSelect) sqlNode).setFrom(((SqlWithItem) fromNode).name);
       }
-    } else if (fromNode instanceof SqlUnpivot
-        && ((SqlUnpivot) fromNode).query instanceof SqlWithItem) {
-      SqlIdentifier identifier = ((SqlWithItem) ((SqlUnpivot) fromNode).query).name;
+    } else if (fromNode instanceof SqlUnpivot) {
       SqlUnpivot unpivot = (SqlUnpivot) fromNode;
-      SqlUnpivot unpivotNode =
-          new SqlUnpivot(unpivot.getParserPosition(), identifier, unpivot.includeNulls,
-              unpivot.measureList, unpivot.axisList, unpivot.inList);
-      ((SqlSelect) sqlNode).setFrom(unpivotNode);
+      SqlNode collapsedQuery = collapseCteReferenceInUnpivotQuery(unpivot.query);
+      if (collapsedQuery != null) {
+        ((SqlSelect) sqlNode).setFrom(
+            new SqlUnpivot(unpivot.getParserPosition(), collapsedQuery, unpivot.includeNulls,
+                unpivot.measureList, unpivot.axisList, unpivot.inList));
+      }
     }
+  }
+
+  /**
+   * Collapses a CTE definition that appears as the input (query) of a {@link SqlUnpivot} back to a
+   * reference to the CTE name, so an UNPIVOT over a CTE emits
+   * {@code FROM cte [AS alias] UNPIVOT (...)} instead of re-inlining the CTE's full definition
+   * (which produced invalid target SQL such as {@code FROM (cte AS (SELECT ...)) AS a UNPIVOT ...}).
+   * Handles both a bare {@link SqlWithItem} ({@code FROM cte UNPIVOT ...}) and an aliased one
+   * wrapped by {@code AS} ({@code FROM cte AS a UNPIVOT ...}). Returns {@code null} when the query is
+   * not a CTE definition, so the caller leaves the FROM untouched.
+   */
+  private static SqlNode collapseCteReferenceInUnpivotQuery(SqlNode query) {
+    if (query instanceof SqlWithItem) {
+      return ((SqlWithItem) query).name;
+    }
+    if (query instanceof SqlBasicCall
+        && ((SqlBasicCall) query).getOperator() instanceof SqlAsOperator
+        && ((SqlBasicCall) query).operand(0) instanceof SqlWithItem) {
+      SqlBasicCall asCall = (SqlBasicCall) query;
+      asCall.setOperand(0, ((SqlWithItem) asCall.operand(0)).name);
+      return asCall;
+    }
+    return null;
   }
 
   private static void processBasicCall(SqlNode sqlNode) {

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
@@ -12316,6 +12316,49 @@ class RelToSqlConverterDMTest {
     assertThat(actualSql, isLinux(expectedSql));
   }
 
+  /** An UNPIVOT whose input is a CTE referenced by an alias must emit the CTE by NAME
+   * ({@code FROM TMP AS a UNPIVOT ...}) rather than re-inlining the CTE definition
+   * ({@code FROM (TMP AS (SELECT ...)) AS a UNPIVOT ...}), which is invalid target SQL. */
+  @Test public void testUnpivotOverCteReferencedByAlias() {
+    final RelBuilder builder = RelBuilder.create(salesConfig().build());
+
+    final RelNode cte = builder
+        .scan("sales")
+        .project(builder.field("jansales"), builder.field("febsales"), builder.field("marsales"))
+        .build();
+
+    // CTE definition trait + a table alias (mirrors what swift attaches for `FROM tmp a`).
+    final CTEDefinationTrait cteTrait = new CTEDefinationTrait(true, "TMP", false);
+    RelTraitSet cteTraits = cte.getTraitSet().plus(cteTrait).plus(new TableAliasTrait("a"));
+    final RelNode cteWithTraits = cte.copy(cteTraits, cte.getInputs());
+
+    final RelNode unpivot = builder
+        .push(cteWithTraits)
+        .unpivot(false, ImmutableList.of("monthly_sales"),
+            ImmutableList.of("month"),
+            Pair.zip(
+                Arrays.asList(ImmutableList.of(builder.literal("jan")),
+                    ImmutableList.of(builder.literal("feb")),
+                    ImmutableList.of(builder.literal("march"))),
+                Arrays.asList(ImmutableList.of(builder.field("jansales")),
+                    ImmutableList.of(builder.field("febsales")),
+                    ImmutableList.of(builder.field("marsales")))))
+        .build();
+
+    // CTE scope trait on the outer node (mirrors the WITH-carrying statement node).
+    final CTEScopeTrait cteScopeTrait = new CTEScopeTrait(true);
+    final RelNode scopeNode =
+        unpivot.copy(unpivot.getTraitSet().plus(cteScopeTrait), unpivot.getInputs());
+
+    final String actualSql = toSql(scopeNode, DatabaseProduct.BIG_QUERY.getDialect());
+
+    final String expectedSql = "WITH TMP AS (SELECT jansales, febsales, marsales\n"
+        + "FROM SALESSCHEMA.sales) (SELECT month, CAST(monthly_sales AS INTEGER) AS monthly_sales\n"
+        + "FROM TMP AS a UNPIVOT EXCLUDE NULLS (monthly_sales FOR month IN "
+        + "(jansales AS 'jan', febsales AS 'feb', marsales AS 'march')))";
+    assertThat(actualSql, isLinux(expectedSql));
+  }
+
   @Test public void testGenerateUUID() {
     final RelBuilder builder = relBuilder();
     final RexNode generateUUID = builder.call(SqlLibraryOperators.GENERATE_UUID);


### PR DESCRIPTION
SDD benchmark reference — RSFB-4907, run 2026-08-10-RSFB-4907-02.
Reference only — never merge. Base = the pre-dev-fix pinned commit, so the diff shows SDD's change against the code the dev saw.
base = bbece0da4bf2; head = bench/2026-08-10-RSFB-4907-02/sdd. Both live in the bench/ namespace — nothing here targets master, exactly like the mig-side reference MRs.
Published by wren/benchmark-replay/scripts/push-calcite-reference-pr.sh; it deliberately carries nothing beyond the Jira id, the run id and the pinned sha.