### PR TITLE
[SDD bench] RMSAD-58 — draft calcite change (reference; do not merge)

### DIFF
--- a/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
+++ b/core/src/main/java/org/apache/calcite/tools/RelBuilder.java
@@ -3571,8 +3571,13 @@ public class RelBuilder {
       }
     }
     if (fetchNode != null) {
-      if (!(fetchNode instanceof RexLiteral || fetchNode instanceof RexDynamicParam)) {
-        throw new IllegalArgumentException("FETCH node must be RexLiteral or RexDynamicParam");
+      // RMSAD-58: SQL Server TOP (n) PERCENT is modelled as a scalar sub-query fetch
+      // (SELECT CAST(CEIL(COUNT(*) * n / 100.0) AS BIGINT) FROM <source>). Allow a
+      // RexSubQuery so mig swift can express a computed, non-literal row count.
+      if (!(fetchNode instanceof RexLiteral || fetchNode instanceof RexDynamicParam
+          || fetchNode instanceof RexSubQuery)) {
+        throw new IllegalArgumentException(
+            "FETCH node must be RexLiteral, RexDynamicParam or RexSubQuery");
       }
     }
 


### PR DESCRIPTION
SDD benchmark reference — RMSAD-58, run 2026-08-11-RMSAD-58-02.
Reference only — never merge. Base = the pre-dev-fix pinned commit, so the diff shows SDD's change against the code the dev saw.
base = 6e4c686b3633; head = bench/2026-08-11-RMSAD-58-02/sdd. Both live in the bench/ namespace — nothing here targets master, exactly like the mig-side reference MRs.
Published by wren/benchmark-replay/scripts/push-calcite-reference-pr.sh; it deliberately carries nothing beyond the Jira id, the run id and the pinned sha.