### PR TITLE
[dev reference] RMSAD-58 — developer's calcite change (reference; do not merge)

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/dialect/PostgresqlSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/PostgresqlSqlDialect.java
@@ -38,6 +38,7 @@ import org.apache.calcite.sql.SqlSelect;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.fun.SqlCase;
 import org.apache.calcite.sql.fun.SqlFloorFunction;
+import org.apache.calcite.sql.fun.SqlLibraryOperators;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.SqlTypeName;
@@ -407,5 +408,47 @@ public class PostgresqlSqlDialect extends SqlDialect {
 
   @Override public boolean supportsGroupByLiteral() {
     return false;
+  }
+
+  /**
+   * PostgreSQL supports "FETCH FIRST n ROWS WITH TIES" syntax which is used
+   * when the fetch clause contains a WITH_TIES operator.
+   * This method overrides the base unparseOffsetFetch to handle WITH_TIES
+   * for PostgreSQL while delegating regular offset/fetch to the parent.
+   */
+  @Override public void unparseOffsetFetch(SqlWriter writer, @Nullable SqlNode offset,
+      @Nullable SqlNode fetch) {
+    if (fetch instanceof SqlCall
+        && ((SqlCall) fetch).getOperator() == SqlLibraryOperators.WITH_TIES) {
+      if (offset != null) {
+        writer.newlineAndIndent();
+        final SqlWriter.Frame offsetFrame =
+            writer.startList(SqlWriter.FrameTypeEnum.OFFSET);
+        writer.keyword("OFFSET");
+        offset.unparse(writer, -1, -1);
+        writer.keyword("ROWS");
+        writer.endList(offsetFrame);
+      }
+      unparseFetchWithTies(writer, (SqlCall) fetch);
+    } else {
+      super.unparseOffsetFetch(writer, offset, fetch);
+    }
+  }
+
+  /**
+   * Helper method to unparse "FETCH FIRST n ROWS WITH TIES" syntax for PostgreSQL.
+   */
+  private static void unparseFetchWithTies(SqlWriter writer, SqlCall fetchWithTies) {
+    final SqlNode fetchValue = fetchWithTies.operand(0);
+    writer.newlineAndIndent();
+    final SqlWriter.Frame fetchFrame =
+        writer.startList(SqlWriter.FrameTypeEnum.FETCH);
+    writer.keyword("FETCH");
+    writer.keyword("FIRST");
+    fetchValue.unparse(writer, -1, -1);
+    writer.keyword("ROWS");
+    writer.keyword("WITH");
+    writer.keyword("TIES");
+    writer.endList(fetchFrame);
   }
 }

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -4932,4 +4932,26 @@ public abstract class SqlLibraryOperators {
           null,
           OperandTypes.family(SqlTypeFamily.DATETIME, SqlTypeFamily.DATETIME),
           SqlFunctionCategory.TIMEDATE);
+
+  /** The "TOP_PERCENT(n)" function represents SQL Server's
+   * {@code SELECT TOP (n) PERCENT} clause. The operand is the percent value.
+   * During rel-to-sql conversion, this is transformed into
+   * {@code FETCH NEXT (SELECT CAST(CEIL(COUNT(*) * n / 100.0) AS BIGINT) FROM table) ROWS ONLY}. */
+  @LibraryOperator(libraries = {MSSQL, POSTGRESQL})
+  public static final SqlFunction PERCENT =
+      SqlBasicFunction.create("PERCENT",
+          ReturnTypes.BIGINT_NULLABLE,
+          OperandTypes.NUMERIC,
+          SqlFunctionCategory.NUMERIC);
+
+  /** The "TOP_WITH_TIES(n)" function represents SQL Server's
+   * {@code SELECT TOP (n) WITH TIES} clause. The operand is the fetch count.
+   * During rel-to-sql conversion, this is unparsed as
+   * {@code FETCH FIRST n ROWS WITH TIES}. */
+  @LibraryOperator(libraries = {MSSQL, POSTGRESQL})
+  public static final SqlFunction WITH_TIES =
+      SqlBasicFunction.create("WITH_TIES",
+          ReturnTypes.BIGINT_NULLABLE,
+          OperandTypes.NUMERIC,
+          SqlFunctionCategory.NUMERIC);
 }

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
@@ -31,6 +31,9 @@ import org.apache.calcite.plan.ViewChildProjectRelTrait;
 import org.apache.calcite.plan.hep.HepPlanner;
 import org.apache.calcite.plan.hep.HepProgram;
 import org.apache.calcite.plan.hep.HepProgramBuilder;
+import org.apache.calcite.rel.RelCollation;
+import org.apache.calcite.rel.RelCollations;
+import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.CorrelationId;
 import org.apache.calcite.rel.core.JoinRelType;
@@ -39,6 +42,7 @@ import org.apache.calcite.rel.logical.LogicalAggregate;
 import org.apache.calcite.rel.logical.LogicalCorrelate;
 import org.apache.calcite.rel.logical.LogicalFilter;
 import org.apache.calcite.rel.logical.LogicalProject;
+import org.apache.calcite.rel.logical.LogicalSort;
 import org.apache.calcite.rel.logical.LogicalValues;
 import org.apache.calcite.rel.logical.ToLogicalConverter;
 import org.apache.calcite.rel.rules.AggregateJoinTransposeRule;
@@ -14665,6 +14669,35 @@ class RelToSqlConverterDMTest {
     assertThat(toSql(root, DatabaseProduct.SNOWFLAKE.getDialect()), isLinux(expectedBigQuery));
   }
 
+  @Test public void testFetchFirstRowsWithTies() {
+    final RelBuilder builder = relBuilder();
+    final RexNode fetchWithTies =
+        builder.call(SqlLibraryOperators.WITH_TIES, builder.literal(5));
+    final RelNode scan = builder.scan("EMP").build();
+    final RelCollation collation = RelCollations.of(new RelFieldCollation(1));
+    final RelNode root = LogicalSort.create(scan, collation, null, fetchWithTies);
+    final String expectedSql = "SELECT *\n"
+        + "FROM \"scott\".\"EMP\"\n"
+        + "ORDER BY \"ENAME\"\n"
+        + "FETCH FIRST 5 ROWS WITH TIES";
+    assertThat(toSql(root, DatabaseProduct.POSTGRESQL.getDialect()), isLinux(expectedSql));
+  }
+
+  @Test public void testFetchFirstRowsWithTiesAndOffset() {
+    final RelBuilder builder = relBuilder();
+    final RexNode fetchWithTies =
+        builder.call(SqlLibraryOperators.WITH_TIES, builder.literal(5));
+    final RelNode scan = builder.scan("EMP").build();
+    final RelCollation collation = RelCollations.of(new RelFieldCollation(1));
+    final RexNode offset = builder.literal(3);
+    final RelNode root = LogicalSort.create(scan, collation, offset, fetchWithTies);
+    final String expectedSql = "SELECT *\n"
+        + "FROM \"scott\".\"EMP\"\n"
+        + "ORDER BY \"ENAME\"\n"
+        + "OFFSET 3 ROWS\n"
+        + "FETCH FIRST 5 ROWS WITH TIES";
+    assertThat(toSql(root, DatabaseProduct.POSTGRESQL.getDialect()), isLinux(expectedSql));
+  }
 
   @Test public void testSkipSimplify() {
     final RelBuilder builder = foodmartRelBuilder();


### PR DESCRIPTION
SDD benchmark reference — RMSAD-58, run 2026-08-11-RMSAD-58-02.
Reference only — never merge. Base = the pre-dev-fix pinned commit, so the diff shows SDD's change against the code the dev saw.
base = 6e4c686b3633; head = bench/2026-08-11-RMSAD-58-02/dev. Both live in the bench/ namespace — nothing here targets master, exactly like the mig-side reference MRs.
Published by wren/benchmark-replay/scripts/push-calcite-reference-pr.sh; it deliberately carries nothing beyond the Jira id, the run id and the pinned sha.