### PR TITLE
Add NGRAM(string1, string2) operator

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -4104,6 +4104,13 @@ public abstract class SqlLibraryOperators {
   @LibraryOperator(libraries = {BIG_QUERY, ORACLE, TERADATA})
   public static final SqlFunction EDIT_DISTANCE = new SqlEditDistanceFunction();
 
+  /**
+   * The NGRAM(string1, string2) returns the number of n-grams
+   * common to both strings.
+   * */
+  @LibraryOperator(libraries = {TERADATA})
+  public static final SqlFunction NGRAM = new SqlNgramFunction();
+
   @LibraryOperator(libraries = {BIG_QUERY})
   public static final SqlFunction GENERATE_UUID =
       new SqlFunction("GENERATE_UUID",

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlNgramFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlNgramFunction.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql.fun;
+
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+
+/**
+ * The NGRAM(string1, string2) returns the number of n-grams
+ * common to both strings.
+ * */
+public class SqlNgramFunction extends SqlFunction {
+
+  public SqlNgramFunction() {
+    super("NGRAM", SqlKind.OTHER_FUNCTION,
+        ReturnTypes.INTEGER_NULLABLE,
+        null, OperandTypes.STRING_STRING, SqlFunctionCategory.NUMERIC);
+  }
+}


### PR DESCRIPTION
# Add NGRAM(string1, string2) operator

Adds a source-neutral `SqlLibraryOperators.NGRAM` operator (backed by `SqlNgramFunction`) so raven can
translate the Teradata `NGRAM(string1, string2)` bigram string-similarity function to BigQuery.

## Change (2 files, mirrors `EDIT_DISTANCE`)
- **NEW** `core/.../sql/fun/SqlNgramFunction.java` — `SqlFunction` with name `NGRAM`,
  `ReturnTypes.INTEGER_NULLABLE`, `OperandTypes.STRING_STRING` (fixed arity 2), `SqlKind.OTHER_FUNCTION`,
  `SqlFunctionCategory.NUMERIC`.
- **EDIT** `core/.../sql/fun/SqlLibraryOperators.java` — `@LibraryOperator(libraries = {TERADATA})
  public static final SqlFunction NGRAM = new SqlNgramFunction();` (auto-registered via reflection).

No new `SqlKind`, no dialect `unparseCall` branch — the operator is a source-neutral typing carrier; the
BigQuery-specific rendering (a bigram-count correlated subquery) lives in the mig `RavenBigQuerySqlDialect`.

## Paired mig MR
This fork PR is the first half of a dual-deliver change. The mig half (swift mapping +
`RavenBigQuerySqlDialect.unparseNgram`) is delivered as a **draft** MR on the mig-v2 GitLab
(`mahesh.raut/raven/sdd-feature/ngram-bigram-count`). **This fork PR must merge first**; then CI publishes the
new `10.27.N`, the mig pin is bumped, and the mig MR is un-drafted and merged.

Paired mig MR: http://taiga.datametica.com/migrations/mig-v2/-/merge_requests/28123 (DRAFT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
