### PR TITLE
[SDD bench] RSFB-4907 — draft calcite change (reference; do not merge)

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/CTERelToSqlUtil.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/CTERelToSqlUtil.java
@@ -300,7 +300,22 @@ public class CTERelToSqlUtil {
           new SqlUnpivot(unpivot.getParserPosition(), identifier, unpivot.includeNulls,
               unpivot.measureList, unpivot.axisList, unpivot.inList);
       ((SqlSelect) sqlNode).setFrom(unpivotNode);
+    } else if (fromNode instanceof SqlUnpivot
+        && isAliasedSqlWithItem(((SqlUnpivot) fromNode).query)) {
+      // CTE referenced WITH AN ALIAS under UNPIVOT: the query operand is AS(SqlWithItem, alias).
+      // Replace the inlined CTE definition with its name, keeping the alias:
+      // (TMP AS (SELECT ...)) AS a UNPIVOT (...)  ->  TMP AS a UNPIVOT (...)
+      SqlBasicCall aliasedQuery = (SqlBasicCall) ((SqlUnpivot) fromNode).query;
+      aliasedQuery.setOperand(0, ((SqlWithItem) aliasedQuery.operand(0)).name);
     }
+  }
+
+  /** Returns whether {@code node} is an AS call whose first operand is a {@link SqlWithItem}
+   * (an aliased CTE reference whose definition got inlined). */
+  private static boolean isAliasedSqlWithItem(SqlNode node) {
+    return node instanceof SqlBasicCall
+        && ((SqlBasicCall) node).getOperator() instanceof SqlAsOperator
+        && ((SqlBasicCall) node).operand(0) instanceof SqlWithItem;
   }
 
   private static void processBasicCall(SqlNode sqlNode) {


### PR DESCRIPTION
SDD benchmark reference — RSFB-4907, run 2026-08-12-RSFB-4907-03.
Reference only — never merge. Base = the pre-dev-fix pinned commit, so the diff shows SDD's change against the code the dev saw.
base = bbece0da4bf2; head = bench/2026-08-12-RSFB-4907-03/sdd. Both live in the bench/ namespace — nothing here targets master, exactly like the mig-side reference MRs.
Published by wren/benchmark-replay/scripts/push-calcite-reference-pr.sh; it deliberately carries nothing beyond the Jira id, the run id and the pinned sha.