### PR TITLE
[dev reference] RSFB-4907 — developer's calcite change (reference; do not merge)

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/CTERelToSqlUtil.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/CTERelToSqlUtil.java
@@ -40,6 +40,7 @@ import org.apache.calcite.sql.SqlUpdate;
 import org.apache.calcite.sql.SqlWith;
 import org.apache.calcite.sql.SqlWithItem;
 import org.apache.calcite.sql.fun.SqlCase;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.util.SqlShuttle;
 
@@ -56,14 +57,8 @@ public class CTERelToSqlUtil {
   }
 
   public static boolean isCteScopeTrait(RelTraitSet relTraitSet) {
-    boolean isCteScopeTrait = false;
     RelTrait relTrait = relTraitSet.getTrait(CTEScopeTraitDef.instance);
-    if (relTrait != null && relTrait instanceof CTEScopeTrait) {
-      if (((CTEScopeTrait) relTrait).isCTEScope()) {
-        isCteScopeTrait = true;
-      }
-    }
-    return isCteScopeTrait;
+    return relTrait instanceof CTEScopeTrait && ((CTEScopeTrait) relTrait).isCTEScope();
   }
 
   public static boolean isCTEScopeOrDefinitionTrait(RelTraitSet relTraitSet) {
@@ -71,14 +66,9 @@ public class CTERelToSqlUtil {
   }
 
   public static boolean isCteDefinationTrait(RelTraitSet relTraitSet) {
-    boolean isCteDefinationTrait = false;
     RelTrait relTrait = relTraitSet.getTrait(CTEDefinationTraitDef.instance);
-    if (relTrait != null && relTrait instanceof CTEDefinationTrait) {
-      if (((CTEDefinationTrait) relTrait).isCTEDefination()) {
-        isCteDefinationTrait = true;
-      }
-    }
-    return isCteDefinationTrait;
+    return relTrait instanceof CTEDefinationTrait
+        && ((CTEDefinationTrait) relTrait).isCTEDefination();
   }
 
   /**
@@ -292,15 +282,43 @@ public class CTERelToSqlUtil {
       } else {
         ((SqlSelect) sqlNode).setFrom(((SqlWithItem) fromNode).name);
       }
-    } else if (fromNode instanceof SqlUnpivot
-        && ((SqlUnpivot) fromNode).query instanceof SqlWithItem) {
-      SqlIdentifier identifier = ((SqlWithItem) ((SqlUnpivot) fromNode).query).name;
-      SqlUnpivot unpivot = (SqlUnpivot) fromNode;
-      SqlUnpivot unpivotNode =
-          new SqlUnpivot(unpivot.getParserPosition(), identifier, unpivot.includeNulls,
-              unpivot.measureList, unpivot.axisList, unpivot.inList);
-      ((SqlSelect) sqlNode).setFrom(unpivotNode);
+    } else if (fromNode instanceof SqlUnpivot) {
+      // Replace inline CTE body in the UNPIVOT's query with just the CTE identifier
+      // (or AS(identifier, alias) when the CTE reference carries a table alias).
+      SqlNode resolvedQuery = resolveUnpivotCteQuery(((SqlUnpivot) fromNode).query);
+      if (resolvedQuery != null) {
+        SqlUnpivot unpivot = (SqlUnpivot) fromNode;
+        SqlUnpivot unpivotNode =
+            new SqlUnpivot(unpivot.getParserPosition(), resolvedQuery, unpivot.includeNulls,
+                unpivot.measureList, unpivot.axisList, unpivot.inList);
+
+        ((SqlSelect) sqlNode).setFrom(unpivotNode);
+      }
     }
+  }
+
+  /**
+   * Returns the replacement query node for an UNPIVOT whose source is a CTE reference,
+   * or {@code null} if no substitution is needed.
+   *
+   * <ul>
+   *   <li>Unaliased ({@code FROM cte UNPIVOT}): query is {@link SqlWithItem}; returns
+   *       the CTE {@link SqlIdentifier}.</li>
+   *   <li>Aliased ({@code FROM cte alias UNPIVOT}): query is {@code AS(SqlWithItem, alias)};
+   *       returns {@code AS(SqlIdentifier, alias)}.</li>
+   * </ul>
+   */
+  private static SqlNode resolveUnpivotCteQuery(SqlNode query) {
+    if (query instanceof SqlWithItem) {
+      return ((SqlWithItem) query).name;
+    }
+    if (query instanceof SqlBasicCall
+        && ((SqlBasicCall) query).operand(0) instanceof SqlWithItem) {
+      SqlBasicCall asCall = (SqlBasicCall) query;
+      SqlIdentifier identifier = ((SqlWithItem) asCall.operand(0)).name;
+      return SqlStdOperatorTable.AS.createCall(SqlParserPos.ZERO, identifier, asCall.operand(1));
+    }
+    return null;
   }
 
   private static void processBasicCall(SqlNode sqlNode) {

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
@@ -12316,6 +12316,47 @@ class RelToSqlConverterDMTest {
     assertThat(actualSql, isLinux(expectedSql));
   }
 
+  /*FROM TMP A UNPIVOT(...) must produce
+    FROM TMP AS A UNPIVOT(...) not FROM (SELECT ...) AS A UNPIVOT(...)*/
+  @Test public void testCTASWithCTEAndAliasedReferenceInUnpivot() {
+    final RelBuilder builder = RelBuilder.create(salesConfig().build());
+    final RelNode cteBody = builder
+        .scan("sales")
+        .project(builder.field("jansales"), builder.field("febsales"), builder.field("marsales"))
+        .build();
+
+    final CTEDefinationTrait cteTrait = new CTEDefinationTrait(true, "TMP", false);
+    final TableAliasTrait aliasTrait = new TableAliasTrait("a");
+    final RelNode cteRel =
+        cteBody.copy(cteBody.getTraitSet().plus(cteTrait).plus(aliasTrait), cteBody.getInputs());
+
+    final RelNode unpivotRel = builder
+        .push(cteRel)
+        .unpivot(false,
+            ImmutableList.of("monthly_sales"),
+            ImmutableList.of("month"),
+            Pair.zip(
+                Arrays.asList(ImmutableList.of(builder.literal("jan")),
+                    ImmutableList.of(builder.literal("feb")),
+                    ImmutableList.of(builder.literal("march"))),
+                Arrays.asList(ImmutableList.of(builder.field("jansales")),
+                    ImmutableList.of(builder.field("febsales")),
+                    ImmutableList.of(builder.field("marsales")))))
+        .build();
+
+    final CTEScopeTrait cteScopeTrait = new CTEScopeTrait(true);
+    final RelNode root =
+        unpivotRel.copy(unpivotRel.getTraitSet().plus(cteScopeTrait), unpivotRel.getInputs());
+
+    // Key: "FROM TMP AS a UNPIVOT" must appear - not the full CTE body inlined
+    final String expectedSql = "WITH TMP AS (SELECT jansales, febsales, marsales\n"
+        + "FROM SALESSCHEMA.sales) "
+        + "(SELECT month, CAST(monthly_sales AS INTEGER) AS monthly_sales\n"
+        + "FROM TMP AS a UNPIVOT EXCLUDE NULLS (monthly_sales FOR month IN "
+        + "(jansales AS 'jan', febsales AS 'feb', marsales AS 'march')))";
+    assertThat(toSql(root, DatabaseProduct.BIG_QUERY.getDialect()), isLinux(expectedSql));
+  }
+
   @Test public void testGenerateUUID() {
     final RelBuilder builder = relBuilder();
     final RexNode generateUUID = builder.call(SqlLibraryOperators.GENERATE_UUID);


### PR DESCRIPTION
SDD benchmark reference — RSFB-4907, run 2026-08-12-RSFB-4907-03.
Reference only — never merge. Base = the pre-dev-fix pinned commit, so the diff shows SDD's change against the code the dev saw.
base = bbece0da4bf2; head = bench/2026-08-12-RSFB-4907-03/dev. Both live in the bench/ namespace — nothing here targets master, exactly like the mig-side reference MRs.
Published by wren/benchmark-replay/scripts/push-calcite-reference-pr.sh; it deliberately carries nothing beyond the Jira id, the run id and the pinned sha.