### PR TITLE
[dev reference] RTB-2383 — developer's calcite change (reference; do not merge)

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
@@ -69,11 +69,11 @@ import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.type.SqlTypeUtil;
 import org.apache.calcite.sql.validate.SqlConformanceEnum;
+import org.apache.calcite.util.BQToNumberUtils;
 import org.apache.calcite.util.CastCallBuilder;
 import org.apache.calcite.util.NlsString;
 import org.apache.calcite.util.SqlCommentUtil;
 import org.apache.calcite.util.TimestampString;
-import org.apache.calcite.util.ToNumberUtils;
 import org.apache.calcite.util.Util;
 import org.apache.calcite.util.format.FormatModel;
 import org.apache.calcite.util.format.FormatModels;
@@ -761,7 +761,7 @@ public class BigQuerySqlDialect extends SqlDialect {
       unparseDiffFunction(writer, call, leftPrec, rightPrec, call.getOperator().getName());
       break;
     case TO_NUMBER:
-      ToNumberUtils.unparseToNumber(writer, call, leftPrec, rightPrec, this);
+      BQToNumberUtils.unparseToNumber(writer, call, leftPrec, rightPrec, this);
       break;
     case NVL:
       SqlNode[] extractNodeOperands = new SqlNode[]{call.operand(0), call.operand(1)};

--- a/core/src/main/java/org/apache/calcite/util/BQToNumberUtils.java
+++ b/core/src/main/java/org/apache/calcite/util/BQToNumberUtils.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.util;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeSystem;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlCharStringLiteral;
+import org.apache.calcite.sql.SqlDialect;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.type.BasicSqlType;
+import org.apache.calcite.sql.type.SqlTypeName;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.math.BigInteger;
+import java.util.Objects;
+
+/**
+ * BigQuery-specific utilities for unparsing the {@code TO_NUMBER} function.
+ */
+public class BQToNumberUtils extends ToNumberUtils {
+
+  private static final BigInteger INT32_MIN = BigInteger.valueOf(Integer.MIN_VALUE);
+  private static final BigInteger INT32_MAX = BigInteger.valueOf(Integer.MAX_VALUE);
+  private static final BigInteger INT64_MIN = BigInteger.valueOf(Long.MIN_VALUE);
+  private static final BigInteger INT64_MAX = BigInteger.valueOf(Long.MAX_VALUE);
+
+  private BQToNumberUtils() {
+  }
+
+  /** Unparses TO_NUMBER for BigQuery with precision-aware CAST target types. */
+  public static void unparseToNumber(
+      SqlWriter writer, SqlCall call, int leftPrec, int rightPrec, SqlDialect dialect) {
+    unparseToNumberAsCast(writer, call, leftPrec, rightPrec, dialect,
+        BQToNumberUtils::resolveBigQueryCastSpec);
+  }
+
+  /**
+   * Resolves the CAST target type spec that {@link #unparseToNumber} would use for a
+   * {@code TO_NUMBER} call. Used to detect redundant {@code CAST(TO_NUMBER(...) AS T)} wrappers.
+   */
+  public static SqlNode resolveCastSpecForCall(SqlCall call, SqlDialect dialect) {
+    return resolveBigQueryCastSpec(call, dialect);
+  }
+
+  private static SqlNode resolveBigQueryCastSpec(SqlCall call, SqlDialect dialect) {
+    if (!(call.operand(0) instanceof SqlCharStringLiteral)) {
+      return castSpecForType(dialect, SqlTypeName.BIGINT);
+    }
+    String value = ((SqlCharStringLiteral) call.operand(0)).getValueAs(String.class);
+    return resolveBigQueryCastSpecFromValue(value, dialect);
+  }
+
+  private static SqlNode resolveBigQueryCastSpecFromValue(String value, SqlDialect dialect) {
+    if (isScientificNotation(value)) {
+      return castSpecForType(dialect, SqlTypeName.DECIMAL);
+    }
+    NumericParts parts = parseNumericParts(value);
+    if (parts.scale == 0) {
+      BigInteger integerValue = parts.toBigInteger();
+      if (integerValue != null) {
+        if (integerValue.compareTo(INT32_MIN) >= 0
+            && integerValue.compareTo(INT32_MAX) <= 0) {
+          return castSpecForType(dialect, SqlTypeName.INTEGER);
+        }
+        if (integerValue.compareTo(INT64_MIN) >= 0
+            && integerValue.compareTo(INT64_MAX) <= 0) {
+          return castSpecForType(dialect, SqlTypeName.BIGINT);
+        }
+      }
+    }
+    if (parts.precision > 76 || parts.scale > 38) {
+      return castSpecForType(dialect, SqlTypeName.DOUBLE);
+    }
+    RelDataType decimalType =
+        new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.DECIMAL,
+            parts.precision, parts.scale);
+    // BigQuery does not allow parameterized types in CAST expressions; use NUMERIC or
+    // BIGNUMERIC without precision and scale.
+    return Objects.requireNonNull(dialect.getCastSpec(decimalType));
+  }
+
+  private static boolean isScientificNotation(String value) {
+    int eIndex = value.toUpperCase().lastIndexOf('E');
+    return eIndex > 0 && eIndex < value.length() - 1;
+  }
+
+  private static NumericParts parseNumericParts(String value) {
+    String trimmed = value.trim();
+    boolean negative = trimmed.startsWith("-");
+    if (negative || trimmed.startsWith("+")) {
+      trimmed = trimmed.substring(1);
+    }
+    int dotIndex = trimmed.indexOf('.');
+    int integerDigits;
+    int scale;
+    if (dotIndex >= 0) {
+      integerDigits = countDigits(trimmed.substring(0, dotIndex));
+      scale = trimmed.substring(dotIndex + 1).length();
+    } else {
+      integerDigits = countDigits(trimmed);
+      scale = 0;
+    }
+    int precision = scale > 0 ? integerDigits + scale : integerDigits;
+    return new NumericParts(trimmed, negative, scale, precision);
+  }
+
+  private static int countDigits(String s) {
+    int count = 0;
+    for (int i = 0; i < s.length(); i++) {
+      if (Character.isDigit(s.charAt(i))) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  /** Parsed numeric components of a TO_NUMBER operand literal. */
+  private static final class NumericParts {
+    private final String unsignedValue;
+    private final boolean negative;
+    private final int scale;
+    private final int precision;
+
+    private NumericParts(String unsignedValue, boolean negative, int scale, int precision) {
+      this.unsignedValue = unsignedValue;
+      this.negative = negative;
+      this.scale = scale;
+      this.precision = precision;
+    }
+
+    private @Nullable BigInteger toBigInteger() {
+      if (scale > 0) {
+        return null;
+      }
+      try {
+        String digits = unsignedValue.replaceAll("[^0-9]", "");
+        if (digits.isEmpty()) {
+          return BigInteger.ZERO;
+        }
+        BigInteger result = new BigInteger(digits);
+        return negative ? result.negate() : result;
+      } catch (NumberFormatException e) {
+        return null;
+      }
+    }
+  }
+}

--- a/core/src/main/java/org/apache/calcite/util/ToNumberUtils.java
+++ b/core/src/main/java/org/apache/calcite/util/ToNumberUtils.java
@@ -33,216 +33,78 @@ import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.BasicSqlType;
 import org.apache.calcite.sql.type.SqlTypeName;
 
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 /**
- * This class is specific to BigQuery, Hive, Spark and Snowflake.
+ * Utilities for unparsing the {@code TO_NUMBER} function for Hive, Spark, MSSQL and Snowflake.
+ *
+ * <p>BigQuery-specific logic lives in {@link BQToNumberUtils}.
  */
 public class ToNumberUtils {
 
-  private ToNumberUtils() {
-  }
+  protected static final String REGEX_REMOVE = "[',$A-Za-z]+";
+  protected static final Pattern HEX_FORMAT_PATTERN = Pattern.compile("^'[Xx]+'$");
 
-  private static String regExRemove = "[',$A-Za-z]+";
+  protected ToNumberUtils() {
+  }
 
   public static void unparseToNumber(
       SqlWriter writer, SqlCall call, int leftPrec, int rightPrec, SqlDialect dialect) {
-    switch (call.getOperandList().size()) {
-    case 1:
-    case 3:
-      if (isOperandLiteral(call) && isOperandNull(call)) {
-        handleNullOperand(writer, leftPrec, rightPrec, dialect);
-      } else {
-        if (call.operand(0) instanceof SqlCharStringLiteral) {
-          String firstOperand = call.operand(0).toString().replaceAll(regExRemove, "");
-          SqlNode[] sqlNode =
-                  new SqlNode[]{SqlLiteral.createCharString(firstOperand.trim(),
-                          SqlParserPos.ZERO)};
-          call.setOperand(0, sqlNode[0]);
-        }
-
-        SqlTypeName sqlTypeName = call.operand(0).toString().contains(".")
-                ? SqlTypeName.FLOAT : SqlTypeName.BIGINT;
-        handleCasting(writer, call, leftPrec, rightPrec, sqlTypeName, dialect);
-      }
-      break;
-    case 2:
-      if (isOperandLiteral(call) && isOperandNull(call)) {
-        handleNullOperand(writer, leftPrec, rightPrec, dialect);
-      } else {
-        if (Pattern.matches("^'[Xx]+'", call.operand(1).toString())) {
-          SqlNode[] sqlNodes =
-                  new SqlNode[]{SqlLiteral.createCharString("0x", SqlParserPos.ZERO),
-                          call.operand(0)};
-          SqlCall extractCall =
-                  new SqlBasicCall(SqlStdOperatorTable.CONCAT, sqlNodes, SqlParserPos.ZERO);
-          call.setOperand(0, extractCall);
-          handleCasting(writer, call, leftPrec, rightPrec, SqlTypeName.BIGINT, dialect);
-
-        } else {
-          SqlTypeName sqlType;
-          if (call.operand(0).toString().contains(".")) {
-            sqlType = SqlTypeName.FLOAT;
-          } else {
-            sqlType = call.operand(0).toString().contains("E")
-                    && call.operand(1).toString().contains("E")
-                    ? SqlTypeName.DECIMAL : SqlTypeName.BIGINT;
-          }
-          if (!(call.operand(0) instanceof SqlIdentifier)) {
-            modifyOperand(call);
-          }
-          handleCasting(writer, call, leftPrec, rightPrec, sqlType, dialect);
-        }
-      }
-      break;
-    default:
-      throw new IllegalArgumentException("Illegal Argument Exception");
-    }
+    unparseToNumberAsCast(writer, call, leftPrec, rightPrec, dialect,
+        ToNumberUtils::resolveDefaultCastSpec);
   }
 
   public static void unparseToNumberSnowFlake(SqlWriter writer, SqlCall call,
-                                              int leftPrec, int rightPrec) {
+      int leftPrec, int rightPrec) {
     switch (call.getOperandList().size()) {
     case 1:
     case 3:
-      SqlNode[] extractNodeOperands;
-      extractNodeOperands = prepareSqlNodes(call);
-      parseToNumber(writer, leftPrec, rightPrec, extractNodeOperands);
+      parseToNumber(writer, leftPrec, rightPrec, prepareSqlNodes(call));
       break;
     case 2:
       if (isFirstOperandCurrencyType(call)) {
         String secondOperand = call.operand(1).toString().replaceAll("[UL]", "\\$")
-                .replace("'", "");
-        extractNodeOperands =
-                new SqlNode[]{call.operand(0), SqlLiteral.createCharString(secondOperand.trim(),
-                        SqlParserPos.ZERO)};
-        parseToNumber(writer, leftPrec, rightPrec, extractNodeOperands);
-
+            .replace("'", "");
+        parseToNumber(writer, leftPrec, rightPrec,
+            new SqlNode[]{call.operand(0),
+                SqlLiteral.createCharString(secondOperand.trim(), SqlParserPos.ZERO)});
       } else if (isOperandNull(call)) {
-
-        extractNodeOperands = new SqlNode[]{new SqlDataTypeSpec(new
-                SqlBasicTypeNameSpec(SqlTypeName.NULL, SqlParserPos.ZERO),
-                SqlParserPos.ZERO)};
-
-        parseToNumber(writer, leftPrec, rightPrec, extractNodeOperands);
-
+        parseToNumber(writer, leftPrec, rightPrec,
+            new SqlNode[]{new SqlDataTypeSpec(
+                new SqlBasicTypeNameSpec(SqlTypeName.NULL, SqlParserPos.ZERO),
+                SqlParserPos.ZERO)});
       } else if (isOperandTypeOfCurrencyOrContainSpace(call)) {
-
-        extractNodeOperands = prepareSqlNodes(call);
-        parseToNumber(writer, leftPrec, rightPrec, extractNodeOperands);
-
+        parseToNumber(writer, leftPrec, rightPrec, prepareSqlNodes(call));
       } else if (call.operand(0).toString().contains(".")) {
-
         String firstOperand =
-                removeSignFromLastOfStringAndAddInBeginning(call,
-                        call.operand(0).toString().replaceAll("[',]", ""));
+            removeSignFromLastOfStringAndAddInBeginning(call,
+                call.operand(0).toString().replaceAll("[',]", ""));
         int scale = firstOperand.split("\\.")[1].length();
-        extractNodeOperands = new SqlNode[]{SqlLiteral
-            .createCharString(firstOperand.trim(), SqlParserPos.ZERO),
-            SqlLiteral.createExactNumeric
-            ("38", SqlParserPos.ZERO), SqlLiteral.createExactNumeric(scale + "",
-            SqlParserPos.ZERO)};
-        parseToNumber(writer, leftPrec, rightPrec, extractNodeOperands);
-
+        parseToNumber(writer, leftPrec, rightPrec,
+            new SqlNode[]{
+                SqlLiteral.createCharString(firstOperand.trim(), SqlParserPos.ZERO),
+                SqlLiteral.createExactNumeric("38", SqlParserPos.ZERO),
+                SqlLiteral.createExactNumeric(String.valueOf(scale), SqlParserPos.ZERO)});
       }
       break;
     default:
-      throw new IllegalArgumentException("Illegal Argument Exception");
+      throw new IllegalArgumentException("Unsupported number of operands: "
+          + call.getOperandList().size());
     }
-  }
-
-  private static void handleCasting(
-      SqlWriter writer, SqlCall call, int leftPrec, int rightPrec,
-      SqlTypeName sqlTypeName, SqlDialect dialect) {
-    SqlNode[] extractNodeOperands =
-            new SqlNode[]{call.operand(0),
-                    dialect.getCastSpec(
-                        new BasicSqlType(
-                            RelDataTypeSystem.DEFAULT, sqlTypeName))};
-    SqlCall extractCallCast =
-        new SqlBasicCall(SqlStdOperatorTable.CAST, extractNodeOperands, SqlParserPos.ZERO);
-    writer.getDialect().unparseCall(writer, extractCallCast, leftPrec, rightPrec);
-  }
-
-  private static void modifyOperand(SqlCall call) {
-    String regEx = "[',$]+";
-    if (call.operand(1).toString().contains("C")) {
-      regEx = "[',$A-Za-z]+";
-    }
-
-    String firstOperand =
-            removeSignFromLastOfStringAndAddInBeginning(call,
-                    call.operand(0).toString().replaceAll(regEx, ""));
-
-    SqlNode[] sqlNode =
-            new SqlNode[]{SqlLiteral.createCharString(firstOperand.trim(), SqlParserPos.ZERO)};
-    call.setOperand(0, sqlNode[0]);
-  }
-
-  private static String removeSignFromLastOfStringAndAddInBeginning(SqlCall call,
-                                                                    String firstOperand) {
-    if (call.operand(1).toString().contains("MI") || call.operand(1).toString().contains("S")) {
-      if (call.operand(0).toString().contains("-")) {
-        firstOperand = firstOperand.replaceAll("-", "");
-        firstOperand = "-" + firstOperand;
-      } else {
-        firstOperand = firstOperand.replaceAll("\\+", "");
-      }
-    }
-    return firstOperand;
-  }
-
-  private static boolean handleNullOperand(
-      SqlWriter writer, int leftPrec, int rightPrec, SqlDialect dialect) {
-    SqlNode[] extractNodeOperands =
-      new SqlNode[]{new SqlDataTypeSpec(
-          new SqlBasicTypeNameSpec(SqlTypeName.NULL,
-        SqlParserPos.ZERO), SqlParserPos.ZERO),
-        dialect.getCastSpec(new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.INTEGER))};
-
-    SqlCall extractCallCast =
-        new SqlBasicCall(SqlStdOperatorTable.CAST, extractNodeOperands, SqlParserPos.ZERO);
-
-    writer.getDialect().unparseCall(writer, extractCallCast, leftPrec, rightPrec);
-    return true;
-  }
-
-  private static boolean isOperandNull(SqlCall call) {
-    for (SqlNode sqlNode : call.getOperandList()) {
-      SqlLiteral literal = (SqlLiteral) sqlNode;
-      if (literal.getValue() == null) {
-        return true;
-      }
-    }
-    return false;
   }
 
   public static void unparseToNumbertoConv(
       SqlWriter writer, SqlCall call, int leftPrec, int rightPrec, SqlDialect dialect) {
-    SqlNode[] sqlNode =
-        new SqlNode[]{call.getOperandList().get(0), SqlLiteral.createExactNumeric("16",
-                SqlParserPos.ZERO),
-        SqlLiteral.createExactNumeric("10", SqlParserPos.ZERO)};
-    SqlCall extractCall =
-        new SqlBasicCall(SqlLibraryOperators.CONV, sqlNode, SqlParserPos.ZERO);
-    call.setOperand(0, extractCall);
+    SqlCall convCall =
+        new SqlBasicCall(SqlLibraryOperators.CONV,
+            new SqlNode[]{
+                call.getOperandList().get(0),
+                SqlLiteral.createExactNumeric("16", SqlParserPos.ZERO),
+                SqlLiteral.createExactNumeric("10", SqlParserPos.ZERO)},
+            SqlParserPos.ZERO);
+    call.setOperand(0, convCall);
     handleCasting(writer, call, leftPrec, rightPrec, SqlTypeName.BIGINT, dialect);
-  }
-
-  private static boolean isOperandLiteral(SqlCall call) {
-    return call.operand(0) instanceof SqlCharStringLiteral || call.operand(0)
-            instanceof SqlLiteral;
-  }
-
-  private static boolean isFirstOperandCurrencyType(SqlCall call) {
-    return call.operand(0).toString().contains("$") && (call.operand(1).toString().contains("L")
-            || call.operand(1).toString().contains("U"));
-  }
-
-  private static boolean isOperandTypeOfCurrencyOrContainSpace(SqlCall call) {
-    return call.operand(1).toString().contains("PR")
-            || (call.operand(0).toString().contains("USD")
-            && call.operand(1).toString().contains("C"));
   }
 
   public static boolean needsCustomUnparsing(SqlCall call) {
@@ -258,34 +120,193 @@ public class ToNumberUtils {
     return false;
   }
 
-  private static SqlNode[] prepareSqlNodes(SqlCall call) {
-    if (isOperandNull(call)) {
-      SqlNode[] extractNodeOperands = new SqlNode[]{new SqlDataTypeSpec(new
-              SqlBasicTypeNameSpec(SqlTypeName.NULL, SqlParserPos.ZERO),
-              SqlParserPos.ZERO)};
-      return extractNodeOperands;
-    }
-    String firstOperand = call.operand(0).toString().replaceAll(regExRemove, "");
-    if (firstOperand.contains(".")) {
-      int scale = firstOperand.split("\\.")[1].length();
-
-      SqlNode[] extractNodeOperands = new SqlNode[]{SqlLiteral
-          .createCharString(firstOperand.trim(), SqlParserPos.ZERO),
-          SqlLiteral.createExactNumeric
-          ("38", SqlParserPos.ZERO), SqlLiteral.createExactNumeric(scale + "",
-          SqlParserPos.ZERO)};
-      return extractNodeOperands;
-    }
-    SqlNode[] extractNodeOperands = new SqlNode[]{SqlLiteral
-            .createCharString(firstOperand.trim(), SqlParserPos.ZERO)};
-    return extractNodeOperands;
+  /** Resolves the CAST target type for a TO_NUMBER call. */
+  @FunctionalInterface
+  protected interface CastSpecResolver {
+    SqlNode resolve(SqlCall call, SqlDialect dialect);
   }
 
-  private static void parseToNumber(SqlWriter writer, int leftPrec, int rightPrec,
-                                    SqlNode[] extractNodeOperands) {
-    SqlCall extractCallCast =
-            new SqlBasicCall(SqlStdOperatorTable.TO_NUMBER, extractNodeOperands, SqlParserPos.ZERO);
+  protected static void unparseToNumberAsCast(
+      SqlWriter writer, SqlCall call, int leftPrec, int rightPrec, SqlDialect dialect,
+      CastSpecResolver castSpecResolver) {
+    if (isOperandLiteral(call) && isOperandNull(call)) {
+      handleNullOperand(writer, leftPrec, rightPrec, dialect);
+      return;
+    }
 
-    SqlStdOperatorTable.TO_NUMBER.unparse(writer, extractCallCast, leftPrec, rightPrec);
+    switch (call.getOperandList().size()) {
+    case 1:
+    case 3:
+      cleanCharStringLiteralOperand(call);
+      castOperand(writer, call, leftPrec, rightPrec, dialect, castSpecResolver);
+      break;
+    case 2:
+      if (isHexFormat(call)) {
+        prependHexPrefix(call);
+        handleCasting(writer, call, leftPrec, rightPrec, SqlTypeName.BIGINT, dialect);
+      } else {
+        if (!(call.operand(0) instanceof SqlIdentifier)) {
+          modifyOperand(call);
+        }
+        castOperand(writer, call, leftPrec, rightPrec, dialect, castSpecResolver);
+      }
+      break;
+    default:
+      throw new IllegalArgumentException("Unsupported number of operands: "
+          + call.getOperandList().size());
+    }
+  }
+
+  protected static void castOperand(
+      SqlWriter writer, SqlCall call, int leftPrec, int rightPrec, SqlDialect dialect,
+      CastSpecResolver castSpecResolver) {
+    SqlNode castSpec = castSpecResolver.resolve(call, dialect);
+    handleCastingWithSpec(writer, call, leftPrec, rightPrec, castSpec);
+  }
+
+  protected static void cleanCharStringLiteralOperand(SqlCall call) {
+    if (call.operand(0) instanceof SqlCharStringLiteral) {
+      String strippedValue = call.operand(0).toString().replaceAll(REGEX_REMOVE, "");
+      call.setOperand(0,
+          SqlLiteral.createCharString(strippedValue.trim(), SqlParserPos.ZERO));
+    }
+  }
+
+  protected static boolean isHexFormat(SqlCall call) {
+    return HEX_FORMAT_PATTERN.matcher(call.operand(1).toString()).matches();
+  }
+
+  protected static void prependHexPrefix(SqlCall call) {
+    SqlCall concatCall =
+        new SqlBasicCall(SqlStdOperatorTable.CONCAT,
+            new SqlNode[]{
+                SqlLiteral.createCharString("0x", SqlParserPos.ZERO),
+                call.operand(0)},
+            SqlParserPos.ZERO);
+    call.setOperand(0, concatCall);
+  }
+
+  private static SqlNode resolveDefaultCastSpec(SqlCall call, SqlDialect dialect) {
+    return castSpecForType(dialect, resolveDefaultSqlTypeName(call));
+  }
+
+  private static SqlTypeName resolveDefaultSqlTypeName(SqlCall call) {
+    String operandText = call.operand(0).toString();
+    if (operandText.contains(".")) {
+      return SqlTypeName.FLOAT;
+    }
+    if (call.getOperandList().size() == 2
+        && operandText.contains("E")
+        && call.operand(1).toString().contains("E")) {
+      return SqlTypeName.DECIMAL;
+    }
+    return SqlTypeName.BIGINT;
+  }
+
+  protected static SqlNode castSpecForType(SqlDialect dialect, SqlTypeName typeName) {
+    return Objects.requireNonNull(
+        dialect.getCastSpec(
+        new BasicSqlType(RelDataTypeSystem.DEFAULT, typeName)));
+  }
+
+  protected static void handleCasting(
+      SqlWriter writer, SqlCall call, int leftPrec, int rightPrec,
+      SqlTypeName sqlTypeName, SqlDialect dialect) {
+    handleCastingWithSpec(writer, call, leftPrec, rightPrec, castSpecForType(dialect, sqlTypeName));
+  }
+
+  protected static void handleCastingWithSpec(
+      SqlWriter writer, SqlCall call, int leftPrec, int rightPrec, SqlNode castSpec) {
+    SqlCall castCall =
+        new SqlBasicCall(SqlStdOperatorTable.CAST,
+            new SqlNode[]{call.operand(0), castSpec},
+            SqlParserPos.ZERO);
+    writer.getDialect().unparseCall(writer, castCall, leftPrec, rightPrec);
+  }
+
+  protected static void modifyOperand(SqlCall call) {
+    String regEx = call.operand(1).toString().contains("C") ? REGEX_REMOVE : "[',$]+";
+    String firstOperand =
+        removeSignFromLastOfStringAndAddInBeginning(call,
+            call.operand(0).toString().replaceAll(regEx, ""));
+    call.setOperand(0,
+        SqlLiteral.createCharString(firstOperand.trim(), SqlParserPos.ZERO));
+  }
+
+  protected static String removeSignFromLastOfStringAndAddInBeginning(SqlCall call,
+      String firstOperand) {
+    if (call.operand(1).toString().contains("MI") || call.operand(1).toString().contains("S")) {
+      if (call.operand(0).toString().contains("-")) {
+        firstOperand = firstOperand.replaceAll("-", "");
+        firstOperand = "-" + firstOperand;
+      } else {
+        firstOperand = firstOperand.replaceAll("\\+", "");
+      }
+    }
+    return firstOperand;
+  }
+
+  protected static void handleNullOperand(
+      SqlWriter writer, int leftPrec, int rightPrec, SqlDialect dialect) {
+    SqlCall castCall =
+        new SqlBasicCall(SqlStdOperatorTable.CAST,
+            new SqlNode[]{
+                new SqlDataTypeSpec(
+                    new SqlBasicTypeNameSpec(SqlTypeName.NULL, SqlParserPos.ZERO),
+                    SqlParserPos.ZERO),
+                castSpecForType(dialect, SqlTypeName.INTEGER)},
+            SqlParserPos.ZERO);
+    writer.getDialect().unparseCall(writer, castCall, leftPrec, rightPrec);
+  }
+
+  protected static boolean isOperandNull(SqlCall call) {
+    for (SqlNode sqlNode : call.getOperandList()) {
+      SqlLiteral literal = (SqlLiteral) sqlNode;
+      if (literal.getValue() == null) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  protected static boolean isOperandLiteral(SqlCall call) {
+    return call.operand(0) instanceof SqlCharStringLiteral
+        || call.operand(0) instanceof SqlLiteral;
+  }
+
+  protected static boolean isFirstOperandCurrencyType(SqlCall call) {
+    return call.operand(0).toString().contains("$") && (call.operand(1).toString().contains("L")
+        || call.operand(1).toString().contains("U"));
+  }
+
+  protected static boolean isOperandTypeOfCurrencyOrContainSpace(SqlCall call) {
+    return call.operand(1).toString().contains("PR")
+        || (call.operand(0).toString().contains("USD")
+        && call.operand(1).toString().contains("C"));
+  }
+
+  protected static SqlNode[] prepareSqlNodes(SqlCall call) {
+    if (isOperandNull(call)) {
+      return new SqlNode[]{new SqlDataTypeSpec(
+          new SqlBasicTypeNameSpec(SqlTypeName.NULL, SqlParserPos.ZERO),
+          SqlParserPos.ZERO)};
+    }
+    String firstOperand = call.operand(0).toString().replaceAll(REGEX_REMOVE, "");
+    if (firstOperand.contains(".")) {
+      int scale = firstOperand.split("\\.")[1].length();
+      return new SqlNode[]{
+          SqlLiteral.createCharString(firstOperand.trim(), SqlParserPos.ZERO),
+          SqlLiteral.createExactNumeric("38", SqlParserPos.ZERO),
+          SqlLiteral.createExactNumeric(String.valueOf(scale), SqlParserPos.ZERO)};
+    }
+    return new SqlNode[]{
+        SqlLiteral.createCharString(firstOperand.trim(), SqlParserPos.ZERO)};
+  }
+
+  protected static void parseToNumber(SqlWriter writer, int leftPrec, int rightPrec,
+      SqlNode[] operands) {
+    SqlCall toNumberCall =
+        new SqlBasicCall(SqlStdOperatorTable.TO_NUMBER, operands, SqlParserPos.ZERO);
+    SqlStdOperatorTable.TO_NUMBER.unparse(writer, toNumberCall, leftPrec, rightPrec);
   }
 }

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
@@ -4621,7 +4621,7 @@ class RelToSqlConverterDMTest {
   @Test public void testToNumberFunctionHandlingFloatingPoint() {
     String query = "select TO_NUMBER('-1.7892','9.9999')";
     final String expected = "SELECT CAST('-1.7892' AS FLOAT)";
-    final String expectedBigQuery = "SELECT CAST('-1.7892' AS FLOAT64)";
+    final String expectedBigQuery = "SELECT CAST('-1.7892' AS NUMERIC)";
     final String expectedSnowFlake = "SELECT TO_NUMBER('-1.7892', 38, 4)";
     sql(query)
         .withHive()
@@ -4779,7 +4779,7 @@ class RelToSqlConverterDMTest {
   @Test public void testToNumberFunctionHandlingFloatingPointWithD() {
     String query = "select TO_NUMBER('1.789','9D999')";
     final String expected = "SELECT CAST('1.789' AS FLOAT)";
-    final String expectedBigQuery = "SELECT CAST('1.789' AS FLOAT64)";
+    final String expectedBigQuery = "SELECT CAST('1.789' AS NUMERIC)";
     final String expectedSnowFlake = "SELECT TO_NUMBER('1.789', 38, 3)";
     sql(query)
         .withHive()
@@ -4795,7 +4795,7 @@ class RelToSqlConverterDMTest {
   @Test public void testToNumberFunctionHandlingWithSingleFloatingPoint() {
     String query = "select TO_NUMBER('1.789')";
     final String expected = "SELECT CAST('1.789' AS FLOAT)";
-    final String expectedBigQuery = "SELECT CAST('1.789' AS FLOAT64)";
+    final String expectedBigQuery = "SELECT CAST('1.789' AS NUMERIC)";
     final String expectedSnowFlake = "SELECT TO_NUMBER('1.789', 38, 3)";
     sql(query)
         .withHive()
@@ -4923,7 +4923,7 @@ class RelToSqlConverterDMTest {
   @Test public void testToNumberFunctionHandlingWithCurrencyNameFloat() {
     String query = "SELECT TO_NUMBER('dollar12.34','L99D99','NLS_CURRENCY=''dollar''')";
     final String expected = "SELECT CAST('12.34' AS FLOAT)";
-    final String expectedBigQuery = "SELECT CAST('12.34' AS FLOAT64)";
+    final String expectedBigQuery = "SELECT CAST('12.34' AS NUMERIC)";
     final String expectedSnowFlake = "SELECT TO_NUMBER('12.34', 38, 2)";
     sql(query)
         .withHive()
@@ -5035,7 +5035,7 @@ class RelToSqlConverterDMTest {
   @Test public void testToNumberFunctionHandlingWithMIDecimal() {
     String query = "SELECT TO_NUMBER ('1.234-', '9.999MI')";
     final String expected = "SELECT CAST('-1.234' AS FLOAT)";
-    final String expectedBigQuery = "SELECT CAST('-1.234' AS FLOAT64)";
+    final String expectedBigQuery = "SELECT CAST('-1.234' AS NUMERIC)";
     final String expectedSnowFlake = "SELECT TO_NUMBER('-1.234', 38, 3)";
     sql(query)
         .withHive()
@@ -5131,7 +5131,7 @@ class RelToSqlConverterDMTest {
   @Test public void testToNumberFunctionHandlingSingleArgumentFloat() {
     final String query = "SELECT TO_NUMBER ('-1.234')";
     final String expected = "SELECT CAST('-1.234' AS FLOAT)";
-    final String expectedBigQuery = "SELECT CAST('-1.234' AS FLOAT64)";
+    final String expectedBigQuery = "SELECT CAST('-1.234' AS NUMERIC)";
     final String expectedSnowFlake = "SELECT TO_NUMBER('-1.234', 38, 3)";
     sql(query)
         .withHive()
@@ -5230,7 +5230,7 @@ class RelToSqlConverterDMTest {
             + "'is_numeric' else 'is not numeric' end";
     final String expected = "SELECT CASE WHEN CAST('12.77' AS FLOAT) IS NOT NULL THEN "
             + "'is_numeric    ' ELSE 'is not numeric' END";
-    final String expectedBigQuery = "SELECT CASE WHEN CAST('12.77' AS FLOAT64) IS NOT NULL THEN "
+    final String expectedBigQuery = "SELECT CASE WHEN CAST('12.77' AS NUMERIC) IS NOT NULL THEN "
             + "'is_numeric    ' ELSE 'is not numeric' END";
     final String expectedSnowFlake = "SELECT CASE WHEN TO_NUMBER('12.77', 38, 2) IS NOT NULL THEN"
             + " 'is_numeric    ' ELSE 'is not numeric' END";
@@ -5248,7 +5248,7 @@ class RelToSqlConverterDMTest {
   @Test public void testToNumberFunctionHandlingWithGDS() {
     String query = "SELECT TO_NUMBER ('12,454.8-', '99G999D9S')";
     final String expected = "SELECT CAST('-12454.8' AS FLOAT)";
-    final String expectedBigQuery = "SELECT CAST('-12454.8' AS FLOAT64)";
+    final String expectedBigQuery = "SELECT CAST('-12454.8' AS NUMERIC)";
     final String expectedSnowFlake = "SELECT TO_NUMBER('-12454.8', 38, 1)";
     sql(query)
         .withHive()
@@ -5261,6 +5261,34 @@ class RelToSqlConverterDMTest {
         .ok(expectedSnowFlake)
         .withMssql()
         .ok(expected);
+  }
+
+  @Test public void testToNumberFunctionHandlingBigQueryHighPrecision() {
+    String query = "SELECT TO_NUMBER('12345678901234567890.123456789012345678')";
+    final String expectedBigQuery =
+        "SELECT CAST('12345678901234567890.123456789012345678' AS BIGNUMERIC)";
+    sql(query)
+        .withBigQuery()
+        .ok(expectedBigQuery);
+  }
+
+  @Test public void testToNumberFunctionHandlingBigQueryLowPrecision() {
+    String query = "SELECT TO_NUMBER('0.00000000000000000012')";
+    final String expectedBigQuery =
+        "SELECT CAST('0.00000000000000000012' AS BIGNUMERIC)";
+    sql(query).withBigQuery().ok(expectedBigQuery);
+  }
+
+  @Test public void testToNumberFunctionHandlingBigQueryLargeInteger() {
+    String query = "SELECT TO_NUMBER('12345678901234567890')";
+    final String expectedBigQuery = "SELECT CAST('12345678901234567890' AS NUMERIC)";
+    sql(query).withBigQuery().ok(expectedBigQuery);
+  }
+
+  @Test public void testToNumberFunctionHandlingBigQuerySmallInteger() {
+    String query = "SELECT TO_NUMBER('42')";
+    final String expectedBigQuery = "SELECT CAST('42' AS INT64)";
+    sql(query).withBigQuery().ok(expectedBigQuery);
   }
 
   @Test public void testAscii() {


### PR DESCRIPTION
SDD benchmark reference — RTB-2383, run 2026-08-12-RTB-2383.
Reference only — never merge. Base = the pre-dev-fix pinned commit, so the diff shows SDD's change against the code the dev saw.
base = 3354aa1db54a; head = bench/2026-08-12-RTB-2383/dev. Both live in the bench/ namespace — nothing here targets master, exactly like the mig-side reference MRs.
Published by wren/benchmark-replay/scripts/push-calcite-reference-pr.sh; it deliberately carries nothing beyond the Jira id, the run id and the pinned sha.