### PR TITLE
[SDD bench] RMSIB-162 — draft calcite change (reference; do not merge)

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql2rel/RelDecorrelator.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/RelDecorrelator.java
@@ -1518,6 +1518,7 @@ public class RelDecorrelator implements ReflectiveVisitor {
     boolean projectPulledAboveLeftCorrelator =
         joinType.generatesNullsOnRight();
 
+    final RelDataTypeFactory typeFactory = relBuilder.getTypeFactory();
     for (Pair<RexNode, String> pair : project.getNamedProjects()) {
       RexNode newProjExpr =
           removeCorrelationExpr(
@@ -1525,9 +1526,19 @@ public class RelDecorrelator implements ReflectiveVisitor {
               projectPulledAboveLeftCorrelator,
               isCount);
 
+      // RMSIB-162: when this correlate is the RHS of a further LEFT correlate
+      // (stacked counted OUTER APPLYs), the enclosing correlate already declares
+      // this column nullable (LOJ can null it). Re-forcing the original count
+      // NOT-NULL type here produces a project whose row type disagrees with the
+      // correlate RelSet ("Cannot add expression of different type to set").
+      // Reconcile nullability with projectPulledAboveLeftCorrelator.
+      final RelDataType reTypeAs =
+          projectPulledAboveLeftCorrelator
+              ? typeFactory.createTypeWithNullability(pair.left.getType(), true)
+              : pair.left.getType();
       newProjExpr = newProjExpr.accept(new RexShuttle() {
         @Override public RexNode visitCall(final RexCall call) {
-          return call.clone(pair.left.getType(), call.operands);
+          return call.clone(reTypeAs, call.operands);
         }
       });
       newProjects.add(newProjExpr, pair.right);


### PR DESCRIPTION
SDD benchmark reference — RMSIB-162, run 2026-08-14-RMSIB-162.
Reference only — never merge. Base = the pre-dev-fix pinned commit, so the diff shows SDD's change against the code the dev saw.
base = 733fe1639dc0; head = bench/2026-08-14-RMSIB-162/sdd. Both live in the bench/ namespace — nothing here targets master, exactly like the mig-side reference MRs.
Published by wren/benchmark-replay/scripts/push-calcite-reference-pr.sh; it deliberately carries nothing beyond the Jira id, the run id and the pinned sha.