### PR TITLE
[dev reference] RMSIB-162 — developer's calcite change (reference; do not merge)

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql2rel/RelDecorrelator.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/RelDecorrelator.java
@@ -1359,8 +1359,13 @@ public class RelDecorrelator implements ReflectiveVisitor {
 
     // Right input positions are shifted by newLeftFieldCount.
     for (int i = 0; i < oldRightFieldCount; i++) {
-      mapOldToNewOutputs.put(i + oldLeftFieldCount,
-          requireNonNull(rightFrame.oldToNewOutputs.get(i)) + newLeftFieldCount);
+      if (oldRight instanceof LogicalAggregate
+          && rightFrame.oldToNewOutputs.get(i) == null) {
+        mapOldToNewOutputs.put(i + oldLeftFieldCount, newLeftFieldCount);
+      } else {
+        mapOldToNewOutputs.put(i + oldLeftFieldCount,
+            requireNonNull(rightFrame.oldToNewOutputs.get(i)) + newLeftFieldCount);
+      }
     }
 
     final NavigableMap<CorDef, Integer> corDefOutputs =
@@ -1411,7 +1416,9 @@ public class RelDecorrelator implements ReflectiveVisitor {
     // figure out the newLocalOrdinal, relative to the newInput.
     int newLocalOrdinal = oldLocalOrdinal;
 
-    if (!frame.oldToNewOutputs.isEmpty()) {
+    if (!frame.oldToNewOutputs.isEmpty()
+        && !((oldInput instanceof LogicalAggregate)
+        && frame.oldToNewOutputs.get(oldLocalOrdinal) == null)) {
       newLocalOrdinal = requireNonNull(frame.oldToNewOutputs.get(oldLocalOrdinal));
     }
 


### PR DESCRIPTION
SDD benchmark reference — RMSIB-162, run 2026-08-14-RMSIB-162.
Reference only — never merge. Base = the pre-dev-fix pinned commit, so the diff shows SDD's change against the code the dev saw.
base = 733fe1639dc0; head = bench/2026-08-14-RMSIB-162/dev. Both live in the bench/ namespace — nothing here targets master, exactly like the mig-side reference MRs.
Published by wren/benchmark-replay/scripts/push-calcite-reference-pr.sh; it deliberately carries nothing beyond the Jira id, the run id and the pinned sha.