### PR TITLE
[SDD bench] RSFB-4324 — draft calcite change (reference; do not merge)

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
@@ -742,7 +742,15 @@ public class RelToSqlConverter extends SqlImplementor
   private SqlUnpivot createUnpivotSqlNodeWithIncludeNulls(Project projectRel,
       SqlImplementor.Builder builder, UnpivotRelToSqlUtil unpivotRelToSqlUtil) {
     RelNode leftRelOfJoin = ((LogicalJoin) projectRel.getInput(0)).getLeft();
-    SqlNode query = dispatch(leftRelOfJoin).asStatement();
+    // RSFB-4324: when the UNPIVOT source is a bare (optionally aliased) table scan,
+    // emit it directly as the UNPIVOT from-item (`<table> AS <alias>`) instead of
+    // wrapping it in a redundant `(SELECT * FROM <table> AS <alias>)` sub-select.
+    // asStatement() promotes the FROM node into a full SELECT, producing the extra
+    // nesting; asFrom() preserves the alias on the table itself.
+    final Result leftResult = dispatch(leftRelOfJoin);
+    SqlNode query = (leftRelOfJoin instanceof TableScan)
+        ? leftResult.asFrom()
+        : leftResult.asStatement();
     LogicalValues valuesRel = unpivotRelToSqlUtil.getLogicalValuesRel(projectRel);
     SqlNodeList axisList = new SqlNodeList(ImmutableList.of
         (new SqlIdentifier(unpivotRelToSqlUtil.getLogicalValueAlias(valuesRel), POS)), POS);

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
@@ -1193,8 +1193,7 @@ class RelToSqlConverterDMTest {
         .build();
     final SqlDialect dialect = DatabaseProduct.BIG_QUERY.getDialect();
     final String expectedSql = "SELECT *\n"
-        + "FROM (SELECT *\n"
-        + "FROM SALESSCHEMA.sales) UNPIVOT INCLUDE NULLS (monthly_sales FOR month IN (jansales "
+        + "FROM SALESSCHEMA.sales UNPIVOT INCLUDE NULLS (monthly_sales FOR month IN (jansales "
         + "AS 'jan', febsales AS 'feb', marsales AS 'march'))";
     assertThat(toSql(root, dialect), isLinux(expectedSql));
   }
@@ -1216,8 +1215,7 @@ class RelToSqlConverterDMTest {
     final SqlDialect dialect = DatabaseProduct.BIG_QUERY.getDialect();
     final String expectedSql = "SELECT id, year, janexpense, febexpense, marexpense, month, "
         + "CAST(monthly_sales AS INTEGER) AS monthly_sales\n"
-        + "FROM (SELECT *\n"
-        + "FROM SALESSCHEMA.sales) UNPIVOT EXCLUDE NULLS (monthly_sales FOR month IN "
+        + "FROM SALESSCHEMA.sales UNPIVOT EXCLUDE NULLS (monthly_sales FOR month IN "
         + "(jansales AS 'jan', febsales AS 'feb', marsales AS 'march'))";
     assertThat(toSql(root, dialect), isLinux(expectedSql));
   }
@@ -1242,8 +1240,7 @@ class RelToSqlConverterDMTest {
         .build();
     final SqlDialect dialect = DatabaseProduct.BIG_QUERY.getDialect();
     final String expectedSql = "SELECT *\n"
-        + "FROM (SELECT *\n"
-        + "FROM SALESSCHEMA.sales) UNPIVOT INCLUDE NULLS ((monthly_sales, monthly_expense) FOR "
+        + "FROM SALESSCHEMA.sales UNPIVOT INCLUDE NULLS ((monthly_sales, monthly_expense) FOR "
         + "month IN ((jansales, janexpense) AS 'jan', (febsales, febexpense) AS 'feb', "
         + "(marsales, marexpense) AS 'march'))";
     assertThat(toSql(root, dialect), isLinux(expectedSql));
@@ -1269,8 +1266,7 @@ class RelToSqlConverterDMTest {
         .build();
     final SqlDialect dialect = DatabaseProduct.BIG_QUERY.getDialect();
     final String expectedSql = "SELECT *\n"
-        + "FROM (SELECT *\n"
-        + "FROM SALESSCHEMA.sales) UNPIVOT EXCLUDE NULLS ((monthly_sales, monthly_expense) FOR "
+        + "FROM SALESSCHEMA.sales UNPIVOT EXCLUDE NULLS ((monthly_sales, monthly_expense) FOR "
         + "month IN ((jansales, janexpense) AS 'jan', (febsales, febexpense) AS 'feb', "
         + "(marsales, marexpense) AS 'march'))";
     assertThat(toSql(root, dialect), isLinux(expectedSql));


### PR DESCRIPTION
SDD benchmark reference — RSFB-4324, run 2026-08-14-RSFB-4324.
Reference only — never merge. Base = the pre-dev-fix pinned commit, so the diff shows SDD's change against the code the dev saw.
base = c1c226d48e2e; head = bench/2026-08-14-RSFB-4324/sdd. Both live in the bench/ namespace — nothing here targets master, exactly like the mig-side reference MRs.
Published by wren/benchmark-replay/scripts/push-calcite-reference-pr.sh; it deliberately carries nothing beyond the Jira id, the run id and the pinned sha.