### PR TITLE
[dev reference] RSFB-4324 — developer's calcite change (reference; do not merge)

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/UnpivotRelToSqlUtil.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/UnpivotRelToSqlUtil.java
@@ -463,8 +463,11 @@ public class UnpivotRelToSqlUtil {
 
     for (int i = 0; i < aliasOfInSqlNodeList.size(); i++) {
       SqlNodeList identifierList = (SqlNodeList) inSqlNodeList.get(0);
-      SqlIdentifier columnName =
-          new SqlIdentifier(((SqlIdentifier) identifierList.get(i)).names.get(1), POS);
+      SqlNode identifier = identifierList.get(i);
+      String name = identifier instanceof SqlBasicCall && identifier.getKind() == SqlKind.CAST
+          ? ((SqlIdentifier) ((SqlBasicCall) identifier).operand(0)).names.get(1)
+          : ((SqlIdentifier) identifier).names.get(1);
+      SqlIdentifier columnName = new SqlIdentifier(name, POS);
       aliasedInSqlNodeList.add(
           SqlStdOperatorTable.AS.createCall(POS, columnName,
               aliasOfInSqlNodeList.get(i)));

--- a/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
@@ -864,6 +864,10 @@ public class SqlDialect {
     return false;
   }
 
+  public boolean hasImplicitTypeCoercionInUnpivot() {
+    return true;
+  }
+
   /**
    * Converts a timestamp to a SQL timestamp literal, e.g.
    * {@code TIMESTAMP '2009-12-17 12:34:56'}.

--- a/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
@@ -489,6 +489,10 @@ public class BigQuerySqlDialect extends SqlDialect {
     return true;
   }
 
+  public boolean hasImplicitTypeCoercionInUnpivot() {
+    return false;
+  }
+
   @Override public boolean castRequiredForStringOperand(RexCall node) {
     if (super.castRequiredForStringOperand(node)) {
       return true;

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
@@ -1193,8 +1193,7 @@ class RelToSqlConverterDMTest {
         .build();
     final SqlDialect dialect = DatabaseProduct.BIG_QUERY.getDialect();
     final String expectedSql = "SELECT *\n"
-        + "FROM (SELECT *\n"
-        + "FROM SALESSCHEMA.sales) UNPIVOT INCLUDE NULLS (monthly_sales FOR month IN (jansales "
+        + "FROM SALESSCHEMA.sales UNPIVOT INCLUDE NULLS (monthly_sales FOR month IN (jansales "
         + "AS 'jan', febsales AS 'feb', marsales AS 'march'))";
     assertThat(toSql(root, dialect), isLinux(expectedSql));
   }
@@ -1216,8 +1215,7 @@ class RelToSqlConverterDMTest {
     final SqlDialect dialect = DatabaseProduct.BIG_QUERY.getDialect();
     final String expectedSql = "SELECT id, year, janexpense, febexpense, marexpense, month, "
         + "CAST(monthly_sales AS INTEGER) AS monthly_sales\n"
-        + "FROM (SELECT *\n"
-        + "FROM SALESSCHEMA.sales) UNPIVOT EXCLUDE NULLS (monthly_sales FOR month IN "
+        + "FROM SALESSCHEMA.sales UNPIVOT EXCLUDE NULLS (monthly_sales FOR month IN "
         + "(jansales AS 'jan', febsales AS 'feb', marsales AS 'march'))";
     assertThat(toSql(root, dialect), isLinux(expectedSql));
   }
@@ -1242,8 +1240,7 @@ class RelToSqlConverterDMTest {
         .build();
     final SqlDialect dialect = DatabaseProduct.BIG_QUERY.getDialect();
     final String expectedSql = "SELECT *\n"
-        + "FROM (SELECT *\n"
-        + "FROM SALESSCHEMA.sales) UNPIVOT INCLUDE NULLS ((monthly_sales, monthly_expense) FOR "
+        + "FROM SALESSCHEMA.sales UNPIVOT INCLUDE NULLS ((monthly_sales, monthly_expense) FOR "
         + "month IN ((jansales, janexpense) AS 'jan', (febsales, febexpense) AS 'feb', "
         + "(marsales, marexpense) AS 'march'))";
     assertThat(toSql(root, dialect), isLinux(expectedSql));
@@ -1269,8 +1266,7 @@ class RelToSqlConverterDMTest {
         .build();
     final SqlDialect dialect = DatabaseProduct.BIG_QUERY.getDialect();
     final String expectedSql = "SELECT *\n"
-        + "FROM (SELECT *\n"
-        + "FROM SALESSCHEMA.sales) UNPIVOT EXCLUDE NULLS ((monthly_sales, monthly_expense) FOR "
+        + "FROM SALESSCHEMA.sales UNPIVOT EXCLUDE NULLS ((monthly_sales, monthly_expense) FOR "
         + "month IN ((jansales, janexpense) AS 'jan', (febsales, febexpense) AS 'feb', "
         + "(marsales, marexpense) AS 'march'))";
     assertThat(toSql(root, dialect), isLinux(expectedSql));


### PR DESCRIPTION
SDD benchmark reference — RSFB-4324, run 2026-08-14-RSFB-4324.
Reference only — never merge. Base = the pre-dev-fix pinned commit, so the diff shows SDD's change against the code the dev saw.
base = c1c226d48e2e; head = bench/2026-08-14-RSFB-4324/dev. Both live in the bench/ namespace — nothing here targets master, exactly like the mig-side reference MRs.
Published by wren/benchmark-replay/scripts/push-calcite-reference-pr.sh; it deliberately carries nothing beyond the Jira id, the run id and the pinned sha.