### PR TITLE
[SDD bench] RMSAD-7 — draft calcite change (reference; do not merge)

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeName.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeName.java
@@ -144,7 +144,14 @@ public enum SqlTypeName {
   TEXT(PrecScale.NO_NO | PrecScale.YES_NO, false, Types.CHAR,
       SqlTypeFamily.CHARACTER),
   SERIAL(PrecScale.NO_NO, false, Types.INTEGER, SqlTypeFamily.NUMERIC),
-  DOUBLE_PRECISION(PrecScale.NO_NO, false, Types.FLOAT, SqlTypeFamily.NUMERIC);
+  DOUBLE_PRECISION(PrecScale.NO_NO, false, Types.FLOAT, SqlTypeFamily.NUMERIC),
+  /** SQL Server UNIQUEIDENTIFIER — a distinct canonical so targets render it their
+   * own way (AlloyDB UUID, BigQuery STRING) instead of collapsing to VARCHAR/JSON. */
+  UUID(PrecScale.NO_NO, false, Types.OTHER, SqlTypeFamily.CHARACTER),
+  /** XML document type (SQL Server XML, Postgres/AlloyDB XML). */
+  XML(PrecScale.NO_NO | PrecScale.YES_NO, false, Types.OTHER, SqlTypeFamily.CHARACTER),
+  /** Hierarchical path type (SQL Server HIERARCHYID -> AlloyDB LTREE). */
+  HIERARCHYID(PrecScale.NO_NO, false, Types.OTHER, SqlTypeFamily.CHARACTER);
 
   public static final int MAX_DATETIME_PRECISION = 3;
 
@@ -177,7 +184,8 @@ public enum SqlTypeName {
           INTERVAL_HOUR_SECOND, INTERVAL_MINUTE, INTERVAL_MINUTE_SECOND,
           INTERVAL_SECOND, TIME_WITH_LOCAL_TIME_ZONE, TIMESTAMP_WITH_LOCAL_TIME_ZONE,
           TIMESTAMP_WITH_TIME_ZONE, FLOAT, MULTISET, JSON,
-          DISTINCT, STRUCTURED, ROW, CURSOR, COLUMN_LIST, VARIANT, VARRAY, ARRAY);
+          DISTINCT, STRUCTURED, ROW, CURSOR, COLUMN_LIST, VARIANT, VARRAY, ARRAY,
+          UUID, XML, HIERARCHYID);
 
   public static final List<SqlTypeName> BOOLEAN_TYPES =
       ImmutableList.of(BOOLEAN);

--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeUtil.java
@@ -1103,6 +1103,9 @@ public abstract class SqlTypeUtil {
         || type.getSqlTypeName() == SqlTypeName.UNKNOWN
         || type.getSqlTypeName() == SqlTypeName.GEOMETRY
         || type.getSqlTypeName() == SqlTypeName.GEOGRAPHY
+        || type.getSqlTypeName() == SqlTypeName.UUID
+        || type.getSqlTypeName() == SqlTypeName.XML
+        || type.getSqlTypeName() == SqlTypeName.HIERARCHYID
         || type.getSqlTypeName() == SqlTypeName.INTERVAL) {
       int precision = typeName.allowsPrec() ? type.getPrecision() : -1;
       // fix up the precision.


### PR DESCRIPTION
SDD benchmark reference — RMSAD-7, run 2026-08-14-RMSAD-7.
Reference only — never merge. Base = the pre-dev-fix pinned commit, so the diff shows SDD's change against the code the dev saw.
base = 6b76ca655d57; head = bench/2026-08-14-RMSAD-7/sdd. Both live in the bench/ namespace — nothing here targets master, exactly like the mig-side reference MRs.
Published by wren/benchmark-replay/scripts/push-calcite-reference-pr.sh; it deliberately carries nothing beyond the Jira id, the run id and the pinned sha.