### PR TITLE
[dev reference] RMSAD-7 — developer's calcite change (reference; do not merge)

### DIFF
--- a/core/src/main/java/org/apache/calcite/rex/RexLiteral.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexLiteral.java
@@ -68,6 +68,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TimeZone;
+import java.util.UUID;
 
 import static org.apache.calcite.linq4j.Nullness.castNonNull;
 import static org.apache.calcite.rel.type.RelDataTypeImpl.NON_NULLABLE_SUFFIX;
@@ -331,6 +332,8 @@ public class RexLiteral extends RexNode {
       return true;
     }
     switch (typeName) {
+    case UUID:
+      return value instanceof UUID;
     case BOOLEAN:
       // Unlike SqlLiteral, we do not allow boolean null.
       return value instanceof Boolean;

--- a/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
@@ -2053,7 +2053,7 @@ public class BigQuerySqlDialect extends SqlDialect {
           sqlFunction.createCall(SqlParserPos.ZERO, new SqlNode[] { call.operand(0) });
       sqlFunction.unparse(writer, timestampSecondsCall, leftPrec, rightPrec);
     } else {
-      castAsDatetime(writer, call, leftPrec, rightPrec, sqlFunction);
+      sqlFunction.unparse(writer, call, leftPrec, rightPrec);
     }
   }
 

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -4013,6 +4013,24 @@ public abstract class SqlLibraryOperators {
           OperandTypes.NILADIC,
           SqlFunctionCategory.SYSTEM);
 
+  @LibraryOperator(libraries = {SQL_SERVER})
+  public static final SqlFunction NEWID =
+      new SqlFunction("NEWID",
+          SqlKind.OTHER_FUNCTION,
+          ReturnTypes.UUID,
+          null,
+          OperandTypes.NILADIC,
+          SqlFunctionCategory.SYSTEM);
+
+  @LibraryOperator(libraries = {SQL_SERVER})
+  public static final SqlFunction NEWSEQUENTIALID =
+      new SqlFunction("NEWSEQUENTIALID",
+          SqlKind.OTHER_FUNCTION,
+          ReturnTypes.UUID,
+          null,
+          OperandTypes.NILADIC,
+          SqlFunctionCategory.SYSTEM);
+
   @LibraryOperator(libraries = {ORACLE})
   public static final SqlFunction UID =
       new SqlFunction("UID",

--- a/core/src/main/java/org/apache/calcite/sql/type/ReturnTypes.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/ReturnTypes.java
@@ -556,6 +556,9 @@ public abstract class ReturnTypes {
   public static final SqlReturnTypeInference VARCHAR_2000 =
       explicit(SqlTypeName.VARCHAR, 2000);
 
+  public static final SqlReturnTypeInference UUID =
+      explicit(SqlTypeName.UUID);
+
   public static final SqlReturnTypeInference JSON =
       explicit(SqlTypeName.JSON);
 

--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeFamily.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeFamily.java
@@ -82,6 +82,8 @@ public enum SqlTypeFamily implements RelDataTypeFamily {
   FUNCTION,
   VARIANT,
   JSON,
+  HIERARCHYID,
+  UUID,
   /** Like ANY, but do not even validate the operand. It may not be an
    * expression. */
   IGNORE;

--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeName.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeName.java
@@ -144,7 +144,10 @@ public enum SqlTypeName {
   TEXT(PrecScale.NO_NO | PrecScale.YES_NO, false, Types.CHAR,
       SqlTypeFamily.CHARACTER),
   SERIAL(PrecScale.NO_NO, false, Types.INTEGER, SqlTypeFamily.NUMERIC),
-  DOUBLE_PRECISION(PrecScale.NO_NO, false, Types.FLOAT, SqlTypeFamily.NUMERIC);
+  DOUBLE_PRECISION(PrecScale.NO_NO, false, Types.FLOAT, SqlTypeFamily.NUMERIC),
+  HIERARCHYID(PrecScale.NO_NO, false, Types.OTHER, SqlTypeFamily.HIERARCHYID),
+  UUID(PrecScale.NO_NO, false, Types.OTHER, SqlTypeFamily.UUID),
+  XML(PrecScale.NO_NO, false, ExtraSqlTypes.SQLXML,  null);
 
   public static final int MAX_DATETIME_PRECISION = 3;
 

--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeUtil.java
@@ -899,6 +899,13 @@ public abstract class SqlTypeUtil {
     if (toTypeName == SqlTypeName.UNKNOWN) {
       return true;
     }
+
+    if (toType.getSqlTypeName() == SqlTypeName.UUID) {
+      return fromType.getSqlTypeName() == SqlTypeName.UUID
+          || fromType.getFamily() == SqlTypeFamily.CHARACTER
+          || fromType.getFamily() == SqlTypeFamily.BINARY;
+    }
+
     if (toType.isStruct() || fromType.isStruct()) {
       if (toTypeName == SqlTypeName.DISTINCT) {
         if (fromTypeName == SqlTypeName.DISTINCT) {

--- a/core/src/test/java/org/apache/calcite/jdbc/CalciteRemoteDriverTest.java
+++ b/core/src/test/java/org/apache/calcite/jdbc/CalciteRemoteDriverTest.java
@@ -319,7 +319,7 @@ class CalciteRemoteDriverTest {
     CalciteAssert.hr()
         .with(CalciteRemoteDriverTest::getRemoteConnection)
         .metaData(CalciteRemoteDriverTest::getTypeInfo)
-        .returns(CalciteAssert.checkResultCount(is(52)));
+        .returns(CalciteAssert.checkResultCount(is(55)));
   }
 
   @Test void testRemoteTableTypes() {

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
@@ -5321,6 +5321,29 @@ class RelToSqlConverterDMTest {
         .ok(expectedSqlBQ);
   }
 
+  @Test public void testNEWIDFunction() {
+    final RelBuilder builder = relBuilder();
+    final RexNode generateUUID = builder.call(SqlLibraryOperators.NEWID);
+    final RelNode root = builder
+        .scan("EMP")
+        .project(generateUUID)
+        .build();
+    final String expectedBqQuery = "SELECT NEWID() AS [$f0]\nFROM [scott].[EMP]";
+    assertThat(toSql(root, DatabaseProduct.MSSQL.getDialect()), isLinux(expectedBqQuery));
+  }
+
+  @Test public void testNEWSEQUENTIALIDFunction() {
+    final RelBuilder builder = relBuilder();
+    final RexNode generateUUID = builder.call(SqlLibraryOperators.NEWSEQUENTIALID);
+    final RelNode root = builder
+        .scan("EMP")
+        .project(generateUUID)
+        .build();
+    final String expectedBqQuery = "SELECT NEWSEQUENTIALID() AS [$f0]\nFROM [scott].[EMP]";
+    assertThat(toSql(root, DatabaseProduct.MSSQL.getDialect()), isLinux(expectedBqQuery));
+  }
+
+
   @Test public void testCurrentUserWithAlias() {
     String query = "select CURRENT_USER myuser from \"product\" where \"product_id\" = 1";
     final String expectedSql = "SELECT CURRENT_USER() MYUSER\n"
@@ -6987,10 +7010,8 @@ class RelToSqlConverterDMTest {
             builder.alias(unixMicrosRexNode, "TM"),
             builder.alias(unixMillisRexNode, "TMI"))
         .build();
-    final String expectedBiqQuery = "SELECT CAST(TIMESTAMP_SECONDS(HIREDATE) AS DATETIME) AS TS, "
-        + "CAST(TIMESTAMP_MICROS(HIREDATE) AS DATETIME) AS TM, CAST(TIMESTAMP_MILLIS(HIREDATE) AS "
-        + "DATETIME) AS TMI\n"
-        + "FROM scott.EMP";
+    final String expectedBiqQuery = "SELECT TIMESTAMP_SECONDS(HIREDATE) AS TS, TIMESTAMP_MICROS"
+        + "(HIREDATE) AS TM, TIMESTAMP_MILLIS(HIREDATE) AS TMI\nFROM scott.EMP";
     assertThat(toSql(root, DatabaseProduct.BIG_QUERY.getDialect()), isLinux(expectedBiqQuery));
   }
 

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -575,7 +575,7 @@ class RelToSqlConverterTest {
         BigQuerySqlDialect.DEFAULT.configureParser(SqlParser.config());
     final Sql sql = fixture()
         .withBigQuery().withLibrary(SqlLibrary.BIG_QUERY).parserConfig(parserConfig);
-    sql.withSql(query).ok("SELECT CAST(TIMESTAMP_SECONDS(CAST(CEIL(3) AS INT64)) AS DATETIME) AS "
+    sql.withSql(query).ok("SELECT TIMESTAMP_SECONDS(CAST(CEIL(3) AS INT64)) AS "
         + "created_thing\nFROM foodmart.product");
   }
 
@@ -586,7 +586,7 @@ class RelToSqlConverterTest {
         BigQuerySqlDialect.DEFAULT.configureParser(SqlParser.config());
     final Sql sql = fixture()
         .withBigQuery().withLibrary(SqlLibrary.BIG_QUERY).parserConfig(parserConfig);
-    sql.withSql(query).ok("SELECT CAST(TIMESTAMP_SECONDS(CAST(FLOOR(3) AS INT64)) AS DATETIME) AS "
+    sql.withSql(query).ok("SELECT TIMESTAMP_SECONDS(CAST(FLOOR(3) AS INT64)) AS "
         + "created_thing\nFROM foodmart.product");
   }
 


### PR DESCRIPTION
SDD benchmark reference — RMSAD-7, run 2026-08-14-RMSAD-7.
Reference only — never merge. Base = the pre-dev-fix pinned commit, so the diff shows SDD's change against the code the dev saw.
base = 6b76ca655d57; head = bench/2026-08-14-RMSAD-7/dev. Both live in the bench/ namespace — nothing here targets master, exactly like the mig-side reference MRs.
Published by wren/benchmark-replay/scripts/push-calcite-reference-pr.sh; it deliberately carries nothing beyond the Jira id, the run id and the pinned sha.