### PR TITLE
[SDD bench] RHB-1316 — draft calcite change (reference; do not merge)

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlSetOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlSetOperator.java
@@ -89,4 +89,50 @@ public class SqlSetOperator extends SqlBinaryOperator {
       SqlValidatorScope operandScope) {
     validator.validateQuery(call, operandScope, validator.getUnknownType());
   }
+
+  @Override public void unparse(
+      SqlWriter writer,
+      SqlCall call,
+      int leftPrec,
+      int rightPrec) {
+    // A set-operator chain is built left-deep: ((a UNION ALL b) UNION ALL c) ...
+    // The inherited SqlBinaryOperator.unparse recurses into operand(0) for every node
+    // in that chain, so a chain of a few hundred nodes (e.g. a multi-row
+    // INSERT ... VALUES rewritten into a UNION ALL of single-row SELECTs) overflows the
+    // JVM stack with a StackOverflowError. Flatten the run of THIS same set operator into
+    // a list and emit it in a single loop, so unparse depth is independent of chain
+    // length. Operand precedences reproduce exactly what the nested binary unparse would
+    // pass, so the rendered SQL is unchanged. (RHB-1316)
+    if (call.operandCount() != 2) {
+      super.unparse(writer, call, leftPrec, rightPrec);
+      return;
+    }
+    final java.util.Deque<SqlNode> operands = new java.util.ArrayDeque<>();
+    SqlNode node = call;
+    while (node instanceof SqlCall
+        && ((SqlCall) node).getOperator() == this
+        && ((SqlCall) node).operandCount() == 2) {
+      final SqlCall setCall = (SqlCall) node;
+      operands.addFirst(setCall.operand(1));
+      node = setCall.operand(0);
+    }
+    operands.addFirst(node);
+
+    final SqlWriter.Frame frame = writer.startList(SqlWriter.FrameTypeEnum.SETOP);
+    final boolean needsSpace = needsSpace();
+    final int lastIndex = operands.size() - 1;
+    int index = 0;
+    for (SqlNode operand : operands) {
+      final int opLeftPrec = (index == 0) ? leftPrec : getRightPrec();
+      final int opRightPrec = (index == lastIndex) ? rightPrec : getLeftPrec();
+      if (index > 0) {
+        writer.setNeedWhitespace(needsSpace);
+        writer.sep(getName());
+        writer.setNeedWhitespace(needsSpace);
+      }
+      operand.unparse(writer, opLeftPrec, opRightPrec);
+      index++;
+    }
+    writer.endList(frame);
+  }
 }

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
@@ -7736,6 +7736,31 @@ class RelToSqlConverterDMTest {
         .withBigQuery().ok(expectedBigQuery);
   }
 
+  /**
+   * RHB-1316: a deep left-deep chain of UNION ALL set operators (produced when a
+   * multi-row INSERT ... VALUES with non-literal row expressions is rewritten into a
+   * UNION ALL of single-row SELECTs) must unparse without a StackOverflowError. The
+   * ticket's INSERT had 499 rows. The inherited {@link SqlBinaryOperator} unparse recurses
+   * down the left spine, one frame group per set-op node, so the chain overflows the stack;
+   * {@link SqlSetOperator#unparse} flattens the same-operator chain iteratively instead.
+   */
+  @Test public void testDeeplyChainedUnionAllDoesNotStackOverflow() {
+    final int rows = 1500;
+    final RelBuilder builder = relBuilder();
+    builder.push(
+        createLogicalValueRel(builder.alias(builder.literal("v0a"), "col1"),
+            builder.alias(builder.literal("v0b"), "col2")));
+    for (int i = 1; i < rows; i++) {
+      builder.push(
+          createLogicalValueRel(builder.alias(builder.literal("v" + i + "a"), "col1"),
+              builder.alias(builder.literal("v" + i + "b"), "col2")));
+      builder.union(true);
+    }
+    final RelNode root = builder.build();
+    final String sql = toSql(root, DatabaseProduct.BIG_QUERY.getDialect());
+    assertThat(sql != null && sql.contains("UNION ALL"), is(true));
+  }
+
   @Test public void testRowid() {
     final RelBuilder builder = relBuilder();
     final RexNode rowidRexNode = builder.call(SqlLibraryOperators.ROWID);


### PR DESCRIPTION
SDD benchmark reference — RHB-1316, run 2026-08-15-RHB-1316.
Reference only — never merge. Base = the pre-dev-fix pinned commit, so the diff shows SDD's change against the code the dev saw.
base = b9b2e5232f66; head = bench/2026-08-15-RHB-1316/sdd. Both live in the bench/ namespace — nothing here targets master, exactly like the mig-side reference MRs.
Published by wren/benchmark-replay/scripts/push-calcite-reference-pr.sh; it deliberately carries nothing beyond the Jira id, the run id and the pinned sha.