### PR TITLE
[dev reference] RHB-1316 — developer's calcite change (reference; do not merge)

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlSetOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlSetOperator.java
@@ -24,6 +24,9 @@ import org.apache.calcite.sql.type.SqlReturnTypeInference;
 import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.sql.validate.SqlValidatorScope;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * SqlSetOperator represents a relational set theory operator (UNION, INTERSECT,
  * MINUS). These are binary operators, but with an extra boolean attribute
@@ -88,5 +91,51 @@ public class SqlSetOperator extends SqlBinaryOperator {
       SqlValidatorScope scope,
       SqlValidatorScope operandScope) {
     validator.validateQuery(call, operandScope, validator.getUnknownType());
+  }
+
+  @Override public void unparse(SqlWriter writer, SqlCall call, int leftPrec, int rightPrec) {
+    assert call.operandCount() == 2;
+    SqlSetOperator rootOp = (SqlSetOperator) call.getOperator();
+    List<SqlNode> operands = new ArrayList<>();
+    flatten(call, rootOp, operands);
+    final SqlWriter.Frame frame = writer.startList(SqlWriter.FrameTypeEnum.SETOP);
+    for (int i = 0; i < operands.size(); i++) {
+      if (i > 0) {
+        writer.sep(getSetOperatorSql(rootOp));
+      }
+      int prec = rootOp.getLeftPrec();
+      operands.get(i).unparse(writer, prec, prec);
+    }
+    writer.endList(frame);
+  }
+
+  private void flatten(SqlNode node, SqlSetOperator rootOp, List<SqlNode> operands) {
+    if (node instanceof SqlCall) {
+      SqlCall call = (SqlCall) node;
+      SqlOperator op = call.getOperator();
+      if (op instanceof SqlSetOperator && sameSetOp(rootOp, (SqlSetOperator) op)) {
+        flatten(call.operand(0), rootOp, operands);
+        flatten(call.operand(1), rootOp, operands);
+        return;
+      }
+    }
+    operands.add(node);
+  }
+
+  private boolean sameSetOp(SqlSetOperator a, SqlSetOperator b) {
+    return a.getKind() == b.getKind() && a.isAll() == b.isAll();
+  }
+
+  private String getSetOperatorSql(SqlSetOperator op) {
+    switch (op.getKind()) {
+    case UNION:
+      return op.isAll() ? "UNION ALL" : "UNION";
+    case INTERSECT:
+      return op.isAll() ? "INTERSECT ALL" : "INTERSECT";
+    case EXCEPT:
+      return op.isAll() ? "EXCEPT ALL" : "EXCEPT";
+    default:
+      throw new AssertionError("Unsupported set operator: " + op.getKind());
+    }
   }
 }

--- a/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
@@ -18,6 +18,7 @@ package org.apache.calcite.sql.dialect;
 
 import org.apache.calcite.avatica.util.Casing;
 import org.apache.calcite.avatica.util.TimeUnit;
+import org.apache.calcite.avatica.util.TimeUnitRange;
 import org.apache.calcite.config.Lex;
 import org.apache.calcite.config.NullCollation;
 import org.apache.calcite.linq4j.Nullness;
@@ -2361,7 +2362,9 @@ public class BigQuerySqlDialect extends SqlDialect {
     if (interval.getSign() == -1) {
       writer.print("-");
     }
-    if (interval.getIntervalQualifier().timeUnitRange.endUnit != null) {
+    if (interval.getIntervalQualifier().timeUnitRange.endUnit != null
+        || (interval.getIntervalQualifier().timeUnitRange == TimeUnitRange.SECOND
+        && interval.getIntervalLiteral().contains("."))) {
       writer.literal("'" + interval.getIntervalLiteral() + "'");
     } else {
       writer.literal(interval.getIntervalLiteral());

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
@@ -14398,4 +14398,12 @@ class RelToSqlConverterDMTest {
 
     assertThat(toSql(root, DatabaseProduct.BIG_QUERY.getDialect()), isLinux(expectedSql));
   }
+
+  @Test public void testIntervalSecondDecimalValue() {
+    final String query = "SELECT INTERVAL '25.500' SECOND interval_sec";
+    final String expectedBiqquery = "SELECT INTERVAL '25.5' SECOND AS INTERVAL_SEC";
+    sql(query)
+        .withBigQuery()
+        .ok(expectedBiqquery);
+  }
 }


### PR DESCRIPTION
SDD benchmark reference — RHB-1316, run 2026-08-15-RHB-1316.
Reference only — never merge. Base = the pre-dev-fix pinned commit, so the diff shows SDD's change against the code the dev saw.
base = b9b2e5232f66; head = bench/2026-08-15-RHB-1316/dev. Both live in the bench/ namespace — nothing here targets master, exactly like the mig-side reference MRs.
Published by wren/benchmark-replay/scripts/push-calcite-reference-pr.sh; it deliberately carries nothing beyond the Jira id, the run id and the pinned sha.