### PR TITLE
[RTB-2620] RTB-2620: BigQuery INTERSECT ALL renders as INTERSECT DISTINCT

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
@@ -712,9 +712,9 @@ public class BigQuerySqlDialect extends SqlDialect {
           rightPrec);
       break;
     case INTERSECT:
-      if (((SqlSetOperator) call.getOperator()).isAll()) {
-        throw new RuntimeException("BigQuery does not support INTERSECT ALL");
-      }
+      // BigQuery has no INTERSECT ALL form; emit INTERSECT DISTINCT (mirrors the
+      // UNION downgrade above) instead of throwing. DM-fork divergence from
+      // Apache upstream, which throws here by design.
       SqlSyntax.BINARY.unparse(writer, INTERSECT_DISTINCT, call, leftPrec,
           rightPrec);
       break;

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
@@ -2016,6 +2016,33 @@ class RelToSqlConverterDMTest {
     sql(query).withBigQuery().ok(expected);
   }
 
+  @Test void testIntersectAllOperatorForBigQuery() {
+    final String query = "select mod(11,3) from \"product\"\n"
+        + "INTERSECT ALL select 1 from \"product\"";
+    final String expected = "SELECT MOD(11, 3)\n"
+        + "FROM foodmart.product\n"
+        + "INTERSECT DISTINCT\n"
+        + "SELECT 1\n"
+        + "FROM foodmart.product";
+    sql(query).withBigQuery().ok(expected);
+  }
+
+  @Test void testChainedIntersectAllOperatorForBigQuery() {
+    final String query = "select \"product_id\" from \"product\"\n"
+        + "INTERSECT ALL select \"product_id\" from \"product\"\n"
+        + "INTERSECT ALL select \"product_id\" from \"product\"";
+    final String expected = "SELECT *\n"
+        + "FROM (SELECT product_id\n"
+        + "FROM foodmart.product\n"
+        + "INTERSECT DISTINCT\n"
+        + "SELECT product_id\n"
+        + "FROM foodmart.product)\n"
+        + "INTERSECT DISTINCT\n"
+        + "SELECT product_id\n"
+        + "FROM foodmart.product";
+    sql(query).withBigQuery().ok(expected);
+  }
+
   @Test public void testIntersectOrderBy() {
     final String query = "select * from (select \"product_id\" from \"product\"\n"
             + "INTERSECT select \"product_id\" from \"product\") t order by t.\"product_id\"";


### PR DESCRIPTION
## RTB-2620: BigQuery renders INTERSECT ALL as INTERSECT DISTINCT (instead of throwing)

### Problem
`BigQuerySqlDialect.unparseCall` is internally inconsistent across set operators: the `UNION` case
downgrades its `ALL`/`DISTINCT` quantifier gracefully (never throws), but the `INTERSECT` and `EXCEPT`
cases **throw** on the `ALL` quantifier. BigQuery has no `INTERSECT ALL` form, so a source
`INTERSECT ALL` aborts translation with `RuntimeException: BigQuery does not support INTERSECT ALL`
even though the well-defined BigQuery equivalent is `INTERSECT DISTINCT`.

### Fix
Make the `INTERSECT` case emit `INTERSECT_DISTINCT` instead of throwing — mirroring the existing `UNION`
downgrade in the same method. Generic, all-consumer change at the dialect-emission layer.

### Divergence note
Apache upstream throws here by design (the `ALL → DISTINCT` downgrade is multiplicity-lossy). This is a
**deliberate DM-fork divergence** — a code comment marks it so a future upstream rebase does not silently
reintroduce the throw. `EXCEPT ALL` is intentionally left throwing (out of this ticket's scope — a
symmetric follow-up candidate).

### Tests
- New `RelToSqlConverterDMTest.testIntersectAllOperatorForBigQuery` (single) and
  `testChainedIntersectAllOperatorForBigQuery` (chained, parenthesised nesting).
- Full `RelToSqlConverterDMTest` suite green (828 pass / 0 fail); red-first confirmed (reverting the
  product change reproduces the exact `RuntimeException`).

### Downstream (MIG)
The mig-v2 pin bump to the published version of this change + a raven regression spec will follow as a
separate mig MR at pin-bump time (this fork PR merges first; CI publishes; the mig pin is then bumped).
Jira: RTB-2620.