### PR TITLE
JAROWINKLER: add Jaro-Winkler similarity operator (Teradata->BigQuery)

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlJaroWinklerFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlJaroWinklerFunction.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.sql.fun;
+
+import org.apache.calcite.sql.SqlCallBinding;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlOperandCountRange;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlOperandCountRanges;
+
+/**
+ * The JAROWINKLER(string1, string2) returns the Jaro-Winkler
+ * similarity (a value between 0 and 1) between two strings.
+ * */
+public class SqlJaroWinklerFunction extends SqlFunction {
+
+  public SqlJaroWinklerFunction() {
+    super("JAROWINKLER", SqlKind.OTHER_FUNCTION,
+        ReturnTypes.DOUBLE_NULLABLE,
+        null, null, SqlFunctionCategory.NUMERIC);
+  }
+
+  @Override public SqlOperandCountRange getOperandCountRange() {
+    return SqlOperandCountRanges.of(2);
+  }
+
+  @Override public boolean checkOperandTypes(SqlCallBinding callBinding,
+      boolean throwOnFailure) {
+    return OperandTypes.STRING_STRING
+        .checkOperandTypes(callBinding, throwOnFailure);
+  }
+}

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -4104,6 +4104,13 @@ public abstract class SqlLibraryOperators {
   @LibraryOperator(libraries = {BIG_QUERY, ORACLE, TERADATA})
   public static final SqlFunction EDIT_DISTANCE = new SqlEditDistanceFunction();
 
+  /**
+   * The JAROWINKLER(string1, string2) returns the Jaro-Winkler
+   * similarity (a value between 0 and 1) between two strings.
+   * */
+  @LibraryOperator(libraries = {BIG_QUERY, ORACLE, TERADATA})
+  public static final SqlFunction JARO_WINKLER = new SqlJaroWinklerFunction();
+
   @LibraryOperator(libraries = {BIG_QUERY})
   public static final SqlFunction GENERATE_UUID =
       new SqlFunction("GENERATE_UUID",

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
@@ -12312,6 +12312,19 @@ class RelToSqlConverterDMTest {
     assertThat(toSql(root, DatabaseProduct.BIG_QUERY.getDialect()), isLinux(expectedBQQuery));
   }
 
+  @Test public void testJaroWinklerFunctionWithTwoArgs() {
+    final RelBuilder builder = relBuilder();
+    final RexNode jaroWinklerRex =
+        builder.call(SqlLibraryOperators.JARO_WINKLER, builder.literal("abc"), builder.literal("xyz"));
+    final RelNode root = builder
+        .scan("EMP")
+        .project(jaroWinklerRex)
+        .build();
+    final String expectedBQQuery = "SELECT JAROWINKLER('abc', 'xyz') AS `$f0`"
+        + "\nFROM scott.EMP";
+    assertThat(toSql(root, DatabaseProduct.BIG_QUERY.getDialect()), isLinux(expectedBQQuery));
+  }
+
   @Test public void testEditDistanceFunctionWithThreeArgs() {
     final RelBuilder builder = relBuilder();
     final RexNode editDistanceRex =


### PR DESCRIPTION
## Add JAROWINKLER (Jaro-Winkler similarity) operator — Teradata → BigQuery

Adds `SqlLibraryOperators.JARO_WINKLER` (`SqlJaroWinklerFunction`, `DOUBLE_NULLABLE` return, exactly 2
STRING operands) so raven can translate Teradata `JAROWINKLER(string1, string2)` to BigQuery. Same class as
the existing `EDIT_DISTANCE` operator, but simpler: the operator name equals the target token, so it renders
native-style `JAROWINKLER(a, b)` via **default unparse** — no `BigQuerySqlDialect` case is needed (EDIT_DISTANCE
has a dialect case only for its 3-arg UDF variant). Includes `RelToSqlConverterDMTest.testJaroWinklerFunctionWithTwoArgs`.

Companion mig MR (source mapping): http://taiga.datametica.com/migrations/mig-v2/-/merge_requests/28331

**Merge order:** fork PR FIRST — CI publishes the new `10.27.N`; then the mig side bumps `calciteCoreVersion`
to it, un-drafts and merges the mig MR.

**⚠ Contract note (verify before merge):** BigQuery has no native `JAROWINKLER`. This renders `JAROWINKLER(a,b)`
native-style (the mig-side chosen rendering); it is runnable on BigQuery only if the target has/deploys a
`JAROWINKLER` function. Confirm with dev/QA; the mig-side runnable alternative is `bqutil.fn.cw_jaro_winkler`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
