### PR TITLE
[RSFB-2314] RSFB-2314: RelToSqlConverter.visit(Snapshot) -> FOR SYSTEM_TIME AS OF

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/RelToSqlConverter.java
@@ -53,6 +53,7 @@ import org.apache.calcite.rel.core.Minus;
 import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.core.Sample;
 import org.apache.calcite.rel.core.Sort;
+import org.apache.calcite.rel.core.Snapshot;
 import org.apache.calcite.rel.core.TableFunctionScan;
 import org.apache.calcite.rel.core.TableModify;
 import org.apache.calcite.rel.core.TableScan;
@@ -98,6 +99,7 @@ import org.apache.calcite.sql.SqlPivot;
 import org.apache.calcite.sql.SqlSampleSpec;
 import org.apache.calcite.sql.SqlSelect;
 import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlSnapshot;
 import org.apache.calcite.sql.SqlTableRef;
 import org.apache.calcite.sql.SqlUnpivot;
 import org.apache.calcite.sql.SqlUpdate;
@@ -1687,6 +1689,22 @@ public class RelToSqlConverter extends SqlImplementor
         SqlStdOperatorTable.TABLESAMPLE.createCall(POS, x.node, tableSampleLiteral);
 
     return result(tableRef, ImmutableList.of(Clause.FROM), e, null);
+  }
+
+  /**
+   * Visits a Snapshot (temporal table reference); called by {@link #dispatch}
+   * via reflection. Renders {@code <tableRef> FOR SYSTEM_TIME AS OF <period>}
+   * (see {@link org.apache.calcite.sql.SqlSnapshot}).
+   */
+  public Result visit(Snapshot e) {
+    // Visit the input (typically a TableScan) to obtain the table SqlNode.
+    final Result x = visitInput(e, 0);
+    // Convert the period RexNode to SQL using the input's aliased context,
+    // mirroring how visit(Join) converts join keys.
+    final SqlNode periodNode = x.qualifiedContext().toSql(null, e.getPeriod());
+    final SqlNode snapshotNode = new SqlSnapshot(POS, x.node, periodNode);
+    // Snapshot is a table reference, so it belongs in the FROM clause.
+    return result(snapshotNode, ImmutableList.of(Clause.FROM), e, null);
   }
 
   private @Nullable SqlIdentifier getDual() {

--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
@@ -108,6 +108,7 @@ import org.apache.calcite.sql.SqlOverOperator;
 import org.apache.calcite.sql.SqlSelect;
 import org.apache.calcite.sql.SqlSelectKeyword;
 import org.apache.calcite.sql.SqlSetOperator;
+import org.apache.calcite.sql.SqlSnapshot;
 import org.apache.calcite.sql.SqlSyntax;
 import org.apache.calcite.sql.SqlTableRef;
 import org.apache.calcite.sql.SqlUnnestOperator;
@@ -654,6 +655,7 @@ public abstract class SqlImplementor {
         || node instanceof SqlIdentifier
         || node instanceof SqlMatchRecognize
         || node instanceof SqlTableRef
+        || node instanceof SqlSnapshot
         || node instanceof SqlCall
             && (((SqlCall) node).getOperator() instanceof SqlSetOperator
                 || ((SqlCall) node).getOperator() == SqlStdOperatorTable.AS

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterDMTest.java
@@ -15269,4 +15269,18 @@ class RelToSqlConverterDMTest {
     final String expectedQuery = "SELECT UUID_STRING() AS \"$f0\"\nFROM \"scott\".\"EMP\"";
     assertThat(toSql(root, DatabaseProduct.SNOWFLAKE.getDialect()), isLinux(expectedQuery));
   }
+
+  /** RSFB-2314: a {@link org.apache.calcite.rel.core.Snapshot} round-trips back to SQL containing
+   * {@code FOR SYSTEM_TIME AS OF} (Snowflake time-travel -> BigQuery). */
+  @Test public void testSnapshotForSystemTimeAsOf() {
+    final RelBuilder builder = relBuilder();
+    final RelNode root =
+        builder.scan("EMP")
+            .snapshot(
+                builder.getRexBuilder().makeTimestampLiteral(
+                    new TimestampString("2011-07-20 12:34:56"), 0))
+            .build();
+    assertThat(toSql(root, DatabaseProduct.BIG_QUERY.getDialect()),
+        containsString("FOR SYSTEM_TIME AS OF"));
+  }
 }


### PR DESCRIPTION
## RSFB-2314 — rel2sql support for temporal Snapshot (FOR SYSTEM_TIME AS OF)

Adds the missing rel→SQL rendering for a `Snapshot` (temporal table) so a `LogicalSnapshot` round-trips to
`<tableRef> FOR SYSTEM_TIME AS OF <period>`. Generic, all-consumer engine behavior — any dialect emitting a
Snapshot benefits. Raven-specific policy (reading the Snowflake AT clause and the BigQuery 7-day retention
cap) stays in mig-v2.

### Change
- `RelToSqlConverter.visit(Snapshot)` — visits the input table, converts the period RexNode via the input's
  qualified context, and wraps both in a `SqlSnapshot` (mirrors `visit(Sample)` / `visit(TableScan)`).
- `SqlImplementor.wrapSelect` — whitelist `SqlSnapshot` as a valid FROM node (it wraps a table reference,
  like `SqlTableRef` / TABLESAMPLE).
- `RelToSqlConverterDMTest.testSnapshotForSystemTimeAsOf` — round-trip asserts the emitted SQL contains
  `FOR SYSTEM_TIME AS OF`.

### Verification
`RelToSqlConverterDMTest` runs green: 827 tests, 0 failures (new test included), red-first confirmed
(without this change the new test fails). No existing rel2sql golden asserts a Snapshot shape, so the
change is inert for existing specs.

### Delivery
Paired with mig-v2 MR **!28339** (DRAFT) which builds the `LogicalSnapshot` + applies the retention cap.
Merge order: this fork PR first → CI publishes the new 10.27.x → the mig MR bumps the pin to it, re-runs
the end-to-end test against the published jar, and un-drafts.

mig MR: http://taiga.datametica.com/migrations/mig-v2/-/merge_requests/28339